### PR TITLE
Translate Item name to Chinese

### DIFF
--- a/TEditXna/settings.xml
+++ b/TEditXna/settings.xml
@@ -618,8 +618,8 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
         <Frame UV="18,760" Name="Golden Chair" Anchor="Right" />
         <Frame UV="0,800" Name="Golden Toilet" Anchor="Left" />
         <Frame UV="18,800" Name="Golden Toilet" Anchor="Right" />
-        <Frame UV="0,840" Name="Barstool" Anchor="Left" />
-        <Frame UV="18,840" Name="Barstool" Anchor="Right" />
+        <Frame UV="0,840" Name="Bar Stool" Anchor="Left" />
+        <Frame UV="18,840" Name="Bar Stool" Anchor="Right" />
         <Frame UV="0,880" Name="Honey Chair" Anchor="Left" />
         <Frame UV="18,880" Name="Honey Chair" Anchor="Right" />
         <Frame UV="0,920" Name="Steampunk Chair" Anchor="Left" />
@@ -1696,7 +1696,7 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
         <Frame UV="432,0" Name="Living Wood Chest" />
         <Frame UV="468,0" Name="Skyware Chest" />
         <Frame UV="504,0" Name="Shadewood Chest" />
-        <Frame UV="540,0" Name="Web Coverd Chest" />
+        <Frame UV="540,0" Name="Web Covered Chest" />
         <Frame UV="576,0" Name="Lihzahrd Chest" />
         <Frame UV="612,0" Name="Water Chest" />
         <Frame UV="648,0" Name="Jungle Chest" />
@@ -2095,8 +2095,8 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
         <Frame UV="18,108" Name="Carriage Lantern" Variety="Off" />
         <Frame UV="0,144" Name="Alchemy Lantern" Variety="On" />
         <Frame UV="18,144" Name="Alchemy Lantern" Variety="Off" />
-        <Frame UV="0,180" Name="Diablost Lamp" Variety="On" />
-        <Frame UV="18,180" Name="Diablost Lamp" Variety="Off" />
+        <Frame UV="0,180" Name="Diabolist Lamp" Variety="On" />
+        <Frame UV="18,180" Name="Diabolist Lamp" Variety="Off" />
         <Frame UV="0,216" Name="Oil Rag Sconse" Variety="On" />
         <Frame UV="18,216" Name="Oil Rag Sconse" Variety="Off" />
         <Frame UV="0,252" Name="Star in a Bottle" Variety="On" />
@@ -4878,9 +4878,9 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
         <Frame UV="0,72" Name="Logic Gate (XOR)" Variety="Off" />
         <Frame UV="18,72" Name="Logic Gate (XOR)" Variety="On" />
         <Frame UV="36,72" Name="Logic Gate (XOR)" Variety="Faulty" />
-        <Frame UV="0,90" Name="Logic Gate (NXOR)" Variety="Off" />
-        <Frame UV="18,90" Name="Logic Gate (NXOR)" Variety="On" />
-        <Frame UV="36,90" Name="Logic Gate (NXOR)" Variety="Faulty" />
+        <Frame UV="0,90" Name="Logic Gate (XNOR)" Variety="Off" />
+        <Frame UV="18,90" Name="Logic Gate (XNOR)" Variety="On" />
+        <Frame UV="36,90" Name="Logic Gate (XNOR)" Variety="Faulty" />
       </Frames>
     </Tile>
     <Tile Id="421" Color="#FF494646" Name="Conveyor Belt (CW)" Solid="true" Blends="true" />
@@ -5557,3935 +5557,3935 @@ PLEASE KEEP FORMATTING IF SUBMITTING PULL REQUEST FOR THIS FILE. THANKS!
     <Item Id="-2" Name="Gold Broadsword Old" />
     <Item Id="-1" Name="Gold Pickaxe Old" />
     <Item Id="0" Name="[empty]" Head="0" Body="0" Legs="0" Rack="true" />
-    <Item Id="1" Name="Iron Pickaxe" Rack="true" />
-    <Item Id="2" Name="Dirt Block" />
-    <Item Id="3" Name="Stone Block" />
-    <Item Id="4" Name="Iron Broadsword" Rack="true" />
-    <Item Id="5" Name="Mushroom" />
-    <Item Id="6" Name="Iron Shortsword" Scale="0.9" Rack="true" />
-    <Item Id="7" Name="Iron Hammer" Scale="1.2" Rack="true" />
-    <Item Id="8" Name="Torch" />
-    <Item Id="9" Name="Wood" />
-    <Item Id="10" Name="Iron Axe" Scale="1.1" Rack="true" />
-    <Item Id="11" Name="Iron Ore" />
-    <Item Id="12" Name="Copper Ore" />
-    <Item Id="13" Name="Gold Ore" />
-    <Item Id="14" Name="Silver Ore" />
-    <Item Id="15" Name="Copper Watch" />
-    <Item Id="16" Name="Silver Watch" />
-    <Item Id="17" Name="Gold Watch" />
-    <Item Id="18" Name="Depth Meter" />
-    <Item Id="19" Name="Gold Bar" />
-    <Item Id="20" Name="Copper Bar" />
-    <Item Id="21" Name="Silver Bar" />
-    <Item Id="22" Name="Iron Bar" />
-    <Item Id="23" Name="Gel" />
-    <Item Id="24" Name="Wooden Sword" Scale="0.95" Rack="true" />
-    <Item Id="25" Name="Wooden Door" />
-    <Item Id="26" Name="Stone Wall" />
-    <Item Id="27" Name="Acorn" />
-    <Item Id="28" Name="Lesser Healing Potion" />
-    <Item Id="29" Name="Life Crystal" />
-    <Item Id="30" Name="Dirt Wall" />
-    <Item Id="31" Name="Bottle" />
-    <Item Id="32" Name="Wooden Table" />
-    <Item Id="33" Name="Furnace" />
-    <Item Id="34" Name="Wooden Chair" />
-    <Item Id="35" Name="Iron Anvil" />
-    <Item Id="36" Name="Work Bench" />
-    <Item Id="37" Name="Goggles" Head="10" />
-    <Item Id="38" Name="Lens" />
-    <Item Id="39" Name="Wooden Bow" Rack="true" />
-    <Item Id="40" Name="Wooden Arrow" Rack="true" />
-    <Item Id="41" Name="Flaming Arrow" Rack="true" />
-    <Item Id="42" Name="Shuriken" Rack="true" />
-    <Item Id="43" Name="Suspicious Looking Eye" />
-    <Item Id="44" Name="Demon Bow" Rack="true" />
-    <Item Id="45" Name="War Axe of the Night" Scale="1.2" Rack="true" />
-    <Item Id="46" Name="Light's Bane" Scale="1.1" Rack="true" />
-    <Item Id="47" Name="Unholy Arrow" Rack="true" />
-    <Item Id="48" Name="Chest" />
-    <Item Id="49" Name="Band of Regeneration" />
-    <Item Id="50" Name="Magic Mirror" />
-    <Item Id="51" Name="Jester's Arrow" Rack="true" />
-    <Item Id="52" Name="Angel Statue" />
-    <Item Id="53" Name="Cloud in a Bottle" />
-    <Item Id="54" Name="Hermes Boots" />
-    <Item Id="55" Name="Enchanted Boomerang" Rack="true" />
-    <Item Id="56" Name="Demonite Ore" />
-    <Item Id="57" Name="Demonite Bar" />
-    <Item Id="58" Name="Heart" />
-    <Item Id="59" Name="Corrupt Seeds" />
-    <Item Id="60" Name="Vile Mushroom" />
-    <Item Id="61" Name="Ebonstone Block" />
-    <Item Id="62" Name="Grass Seeds" />
-    <Item Id="63" Name="Sunflower" />
-    <Item Id="64" Name="Vilethorn" Rack="true" />
-    <Item Id="65" Name="Starfury" Scale="1.25" Rack="true" />
-    <Item Id="66" Name="Purification Powder" />
-    <Item Id="67" Name="Vile Powder" />
-    <Item Id="68" Name="Rotten Chunk" />
-    <Item Id="69" Name="Worm Tooth" />
-    <Item Id="70" Name="Worm Food" />
-    <Item Id="71" Name="Copper Coin" Rack="true" />
-    <Item Id="72" Name="Silver Coin" Rack="true" />
-    <Item Id="73" Name="Gold Coin" Rack="true" />
-    <Item Id="74" Name="Platinum Coin" Rack="true" />
-    <Item Id="75" Name="Fallen Star" />
-    <Item Id="76" Name="Copper Greaves" Legs="1" />
-    <Item Id="77" Name="Iron Greaves" Legs="2" />
-    <Item Id="78" Name="Silver Greaves" Legs="3" />
-    <Item Id="79" Name="Gold Greaves" Legs="4" />
-    <Item Id="80" Name="Copper Chainmail" Body="1" />
-    <Item Id="81" Name="Iron Chainmail" Body="2" />
-    <Item Id="82" Name="Silver Chainmail" Body="3" />
-    <Item Id="83" Name="Gold Chainmail" Body="4" />
-    <Item Id="84" Name="Grappling Hook" />
-    <Item Id="85" Name="Chain" />
-    <Item Id="86" Name="Shadow Scale" />
-    <Item Id="87" Name="Piggy Bank" />
-    <Item Id="88" Name="Mining Helmet" Head="11" />
-    <Item Id="89" Name="Copper Helmet" Head="1" />
-    <Item Id="90" Name="Iron Helmet" Head="2" />
-    <Item Id="91" Name="Silver Helmet" Head="3" />
-    <Item Id="92" Name="Gold Helmet" Head="4" />
-    <Item Id="93" Name="Wood Wall" />
-    <Item Id="94" Name="Wood Platform" />
-    <Item Id="95" Name="Flintlock Pistol" Scale="0.9" Rack="true" />
-    <Item Id="96" Name="Musket" Rack="true" />
-    <Item Id="97" Name="Musket Ball" Rack="true" />
-    <Item Id="98" Name="Minishark" Rack="true" />
-    <Item Id="99" Name="Iron Bow" Rack="true" />
-    <Item Id="100" Name="Shadow Greaves" Legs="5" />
-    <Item Id="101" Name="Shadow Scalemail" Body="5" />
-    <Item Id="102" Name="Shadow Helmet" Head="5" />
-    <Item Id="103" Name="Nightmare Pickaxe" Scale="1.15" Rack="true" />
-    <Item Id="104" Name="The Breaker" Scale="1.3" Rack="true" />
-    <Item Id="105" Name="Candle" />
-    <Item Id="106" Name="Copper Chandelier" />
-    <Item Id="107" Name="Silver Chandelier" />
-    <Item Id="108" Name="Gold Chandelier" />
-    <Item Id="109" Name="Mana Crystal" />
-    <Item Id="110" Name="Lesser Mana Potion" />
-    <Item Id="111" Name="Band of Starpower" />
-    <Item Id="112" Name="Flower of Fire" Rack="true" />
-    <Item Id="113" Name="Magic Missile" Rack="true" />
-    <Item Id="114" Name="Dirt Rod" />
-    <Item Id="115" Name="Shadow Orb" Rack="true" />
-    <Item Id="116" Name="Meteorite" />
-    <Item Id="117" Name="Meteorite Bar" />
-    <Item Id="118" Name="Hook" />
-    <Item Id="119" Name="Flamarang" Rack="true" />
-    <Item Id="120" Name="Molten Fury" Scale="1.1" Rack="true" />
-    <Item Id="121" Name="Fiery Greatsword" Scale="1.3" Rack="true" />
-    <Item Id="122" Name="Molten Pickaxe" Scale="1.15" Rack="true" />
-    <Item Id="123" Name="Meteor Helmet" Head="6" />
-    <Item Id="124" Name="Meteor Suit" Body="6" />
-    <Item Id="125" Name="Meteor Leggings" Legs="6" />
-    <Item Id="126" Name="Bottled Water" />
-    <Item Id="127" Name="Space Gun" Scale="0.8" Rack="true" />
-    <Item Id="128" Name="Rocket Boots" />
-    <Item Id="129" Name="Gray Brick" />
-    <Item Id="130" Name="Gray Brick Wall" />
-    <Item Id="131" Name="Red Brick" />
-    <Item Id="132" Name="Red Brick Wall" />
-    <Item Id="133" Name="Clay Block" />
-    <Item Id="134" Name="Blue Brick" />
-    <Item Id="135" Name="Blue Brick Wall" />
-    <Item Id="136" Name="Chain Lantern" />
-    <Item Id="137" Name="Green Brick" />
-    <Item Id="138" Name="Green Brick Wall" />
-    <Item Id="139" Name="Pink Brick" />
-    <Item Id="140" Name="Pink Brick Wall" />
-    <Item Id="141" Name="Gold Brick" />
-    <Item Id="142" Name="Gold Brick Wall" />
-    <Item Id="143" Name="Silver Brick" />
-    <Item Id="144" Name="Silver Brick Wall" />
-    <Item Id="145" Name="Copper Brick" />
-    <Item Id="146" Name="Copper Brick Wall" />
-    <Item Id="147" Name="Spike" />
-    <Item Id="148" Name="Water Candle" />
-    <Item Id="149" Name="Book" />
-    <Item Id="150" Name="Cobweb" />
-    <Item Id="151" Name="Necro Helmet" Head="7" />
-    <Item Id="152" Name="Necro Breastplate" Body="7" />
-    <Item Id="153" Name="Necro Greaves" Legs="7" />
-    <Item Id="154" Name="Bone" Rack="true" />
-    <Item Id="155" Name="Muramasa" Scale="1.1" Rack="true" />
-    <Item Id="156" Name="Cobalt Shield" />
-    <Item Id="157" Name="Aqua Scepter" Rack="true" />
-    <Item Id="158" Name="Lucky Horseshoe" />
-    <Item Id="159" Name="Shiny Red Balloon" />
-    <Item Id="160" Name="Harpoon" Scale="1.1" Rack="true" />
-    <Item Id="161" Name="Spiky Ball" Rack="true" />
-    <Item Id="162" Name="Ball O' Hurt" Scale="1.1" Rack="true" />
-    <Item Id="163" Name="Blue Moon" Scale="1.1" Rack="true" />
-    <Item Id="164" Name="Handgun" Scale="0.85" Rack="true" />
-    <Item Id="165" Name="Water Bolt" Scale="0.9" Rack="true" />
-    <Item Id="166" Name="Bomb" />
-    <Item Id="167" Name="Dynamite" />
-    <Item Id="168" Name="Grenade" Rack="true" />
-    <Item Id="169" Name="Sand Block" />
-    <Item Id="170" Name="Glass" />
-    <Item Id="171" Name="Sign" />
-    <Item Id="172" Name="Ash Block" />
-    <Item Id="173" Name="Obsidian" />
-    <Item Id="174" Name="Hellstone" />
-    <Item Id="175" Name="Hellstone Bar" />
-    <Item Id="176" Name="Mud Block" />
-    <Item Id="177" Name="Sapphire" />
-    <Item Id="178" Name="Ruby" />
-    <Item Id="179" Name="Emerald" />
-    <Item Id="180" Name="Topaz" />
-    <Item Id="181" Name="Amethyst" />
-    <Item Id="182" Name="Diamond" />
-    <Item Id="183" Name="Glowing Mushroom" />
-    <Item Id="184" Name="Star" />
-    <Item Id="185" Name="Ivy Whip" Rack="true" />
-    <Item Id="186" Name="Breathing Reed" />
-    <Item Id="187" Name="Flipper" />
-    <Item Id="188" Name="Healing Potion" />
-    <Item Id="189" Name="Mana Potion" />
-    <Item Id="190" Name="Blade of Grass" Scale="1.4" Rack="true" />
-    <Item Id="191" Name="Thorn Chakram" Rack="true" />
-    <Item Id="192" Name="Obsidian Brick" />
-    <Item Id="193" Name="Obsidian Skull" />
-    <Item Id="194" Name="Mushroom Grass Seeds" />
-    <Item Id="195" Name="Jungle Grass Seeds" />
-    <Item Id="196" Name="Wooden Hammer" Scale="1.2" Rack="true" />
-    <Item Id="197" Name="Star Cannon" Rack="true" />
-    <Item Id="198" Name="Blue Phaseblade" Rack="true" />
-    <Item Id="199" Name="Red Phaseblade" Rack="true" />
-    <Item Id="200" Name="Green Phaseblade" Rack="true" />
-    <Item Id="201" Name="Purple Phaseblade" Rack="true" />
-    <Item Id="202" Name="White Phaseblade" Rack="true" />
-    <Item Id="203" Name="Yellow Phaseblade" Rack="true" />
-    <Item Id="204" Name="Meteor Hamaxe" Scale="1.2" Rack="true" />
-    <Item Id="205" Name="Empty Bucket" Head="13" />
-    <Item Id="206" Name="Water Bucket" />
-    <Item Id="207" Name="Lava Bucket" />
-    <Item Id="208" Name="Jungle Rose" Head="23" />
-    <Item Id="209" Name="Stinger" />
-    <Item Id="210" Name="Vine" />
-    <Item Id="211" Name="Feral Claws" />
-    <Item Id="212" Name="Anklet of the Wind" />
-    <Item Id="213" Name="Staff of Regrowth" Rack="true" />
-    <Item Id="214" Name="Hellstone Brick" />
-    <Item Id="215" Name="Whoopie Cushion" />
-    <Item Id="216" Name="Shackle" />
-    <Item Id="217" Name="Molten Hamaxe" Scale="1.4" Rack="true" />
-    <Item Id="218" Name="Flamelash" Rack="true" />
-    <Item Id="219" Name="Phoenix Blaster" Scale="0.85" Rack="true" />
-    <Item Id="220" Name="Sunfury" Scale="1.1" Rack="true" />
-    <Item Id="221" Name="Hellforge" />
-    <Item Id="222" Name="Clay Pot" />
-    <Item Id="223" Name="Nature's Gift" />
-    <Item Id="224" Name="Bed" />
-    <Item Id="225" Name="Silk" />
-    <Item Id="226" Name="Lesser Restoration Potion" />
-    <Item Id="227" Name="Restoration Potion" />
-    <Item Id="228" Name="Jungle Hat" Head="8" />
-    <Item Id="229" Name="Jungle Shirt" Body="8" />
-    <Item Id="230" Name="Jungle Pants" Legs="8" />
-    <Item Id="231" Name="Molten Helmet" Head="9" />
-    <Item Id="232" Name="Molten Breastplate" Body="9" />
-    <Item Id="233" Name="Molten Greaves" Legs="9" />
-    <Item Id="234" Name="Meteor Shot" Rack="true" />
-    <Item Id="235" Name="Sticky Bomb" />
-    <Item Id="236" Name="Black Lens" />
-    <Item Id="237" Name="Sunglasses" Head="12" />
-    <Item Id="238" Name="Wizard Hat" Head="14" />
-    <Item Id="239" Name="Top Hat" Head="15" />
-    <Item Id="240" Name="Tuxedo Shirt" Body="10" />
-    <Item Id="241" Name="Tuxedo Pants" Legs="10" />
-    <Item Id="242" Name="Summer Hat" Head="16" />
-    <Item Id="243" Name="Bunny Hood" Head="17" />
-    <Item Id="244" Name="Plumber's Hat" Head="18" />
-    <Item Id="245" Name="Plumber's Shirt" Body="11" />
-    <Item Id="246" Name="Plumber's Pants" Legs="11" />
-    <Item Id="247" Name="Hero's Hat" Head="19" />
-    <Item Id="248" Name="Hero's Shirt" Body="12" />
-    <Item Id="249" Name="Hero's Pants" Legs="12" />
-    <Item Id="250" Name="Fish Bowl" Head="20" />
-    <Item Id="251" Name="Archaeologist's Hat" Head="21" />
-    <Item Id="252" Name="Archaeologist's Jacket" Body="13" />
-    <Item Id="253" Name="Archaeologist's Pants" Legs="13" />
-    <Item Id="254" Name="Black Thread" />
-    <Item Id="255" Name="Green Thread" />
-    <Item Id="256" Name="Ninja Hood" Head="22" />
-    <Item Id="257" Name="Ninja Shirt" Body="14" />
-    <Item Id="258" Name="Ninja Pants" Legs="14" />
-    <Item Id="259" Name="Leather" />
-    <Item Id="260" Name="Red Hat" Head="24" />
-    <Item Id="261" Name="Goldfish" />
-    <Item Id="262" Name="Robe" Body="15" />
-    <Item Id="263" Name="Robot Hat" Head="25" />
-    <Item Id="264" Name="Gold Crown" Head="26" />
-    <Item Id="265" Name="Hellfire Arrow" Rack="true" />
-    <Item Id="266" Name="Sandgun" Rack="true" />
-    <Item Id="267" Name="Guide Voodoo Doll" />
-    <Item Id="268" Name="Diving Helmet" Head="27" />
-    <Item Id="269" Name="Familiar Shirt" />
-    <Item Id="270" Name="Familiar Pants" />
-    <Item Id="271" Name="Familiar Wig" />
-    <Item Id="272" Name="Demon Scythe" Scale="0.9" Rack="true" />
-    <Item Id="273" Name="Night's Edge" Scale="1.15" Rack="true" />
-    <Item Id="274" Name="Dark Lance" Scale="1.1" Rack="true" />
-    <Item Id="275" Name="Coral" />
-    <Item Id="276" Name="Cactus" />
-    <Item Id="277" Name="Trident" Scale="1.1" Rack="true" />
-    <Item Id="278" Name="Silver Bullet" Rack="true" />
-    <Item Id="279" Name="Throwing Knife" Rack="true" />
-    <Item Id="280" Name="Spear" Rack="true" />
-    <Item Id="281" Name="Blowpipe" Rack="true" />
-    <Item Id="282" Name="Glowstick" />
-    <Item Id="283" Name="Seed" Rack="true" />
-    <Item Id="284" Name="Wooden Boomerang" Rack="true" />
-    <Item Id="285" Name="Aglet" />
-    <Item Id="286" Name="Sticky Glowstick" />
-    <Item Id="287" Name="Poisoned Knife" Rack="true" />
-    <Item Id="288" Name="Obsidian Skin Potion" />
-    <Item Id="289" Name="Regeneration Potion" />
-    <Item Id="290" Name="Swiftness Potion" />
-    <Item Id="291" Name="Gills Potion" />
-    <Item Id="292" Name="Ironskin Potion" />
-    <Item Id="293" Name="Mana Regeneration Potion" />
-    <Item Id="294" Name="Magic Power Potion" />
-    <Item Id="295" Name="Featherfall Potion" />
-    <Item Id="296" Name="Spelunker Potion" />
-    <Item Id="297" Name="Invisibility Potion" />
-    <Item Id="298" Name="Shine Potion" />
-    <Item Id="299" Name="Night Owl Potion" />
-    <Item Id="300" Name="Battle Potion" />
-    <Item Id="301" Name="Thorns Potion" />
-    <Item Id="302" Name="Water Walking Potion" />
-    <Item Id="303" Name="Archery Potion" />
-    <Item Id="304" Name="Hunter Potion" />
-    <Item Id="305" Name="Gravitation Potion" />
-    <Item Id="306" Name="Gold Chest" />
-    <Item Id="307" Name="Daybloom Seeds" />
-    <Item Id="308" Name="Moonglow Seeds" />
-    <Item Id="309" Name="Blinkroot Seeds" />
-    <Item Id="310" Name="Deathweed Seeds" />
-    <Item Id="311" Name="Waterleaf Seeds" />
-    <Item Id="312" Name="Fireblossom Seeds" />
-    <Item Id="313" Name="Daybloom" />
-    <Item Id="314" Name="Moonglow" />
-    <Item Id="315" Name="Blinkroot" />
-    <Item Id="316" Name="Deathweed" />
-    <Item Id="317" Name="Waterleaf" />
-    <Item Id="318" Name="Fireblossom" />
-    <Item Id="319" Name="Shark Fin" />
-    <Item Id="320" Name="Feather" />
-    <Item Id="321" Name="Tombstone" />
-    <Item Id="322" Name="Mime Mask" Head="28" />
-    <Item Id="323" Name="Antlion Mandible" />
-    <Item Id="324" Name="Illegal Gun Parts" />
-    <Item Id="325" Name="The Doctor's Shirt" Body="16" />
-    <Item Id="326" Name="The Doctor's Pants" Legs="15" />
-    <Item Id="327" Name="Golden Key" />
-    <Item Id="328" Name="Shadow Chest" />
-    <Item Id="329" Name="Shadow Key" />
-    <Item Id="330" Name="Obsidian Brick Wall" />
-    <Item Id="331" Name="Jungle Spores" />
-    <Item Id="332" Name="Loom" />
-    <Item Id="333" Name="Piano" />
-    <Item Id="334" Name="Dresser" />
-    <Item Id="335" Name="Bench" />
-    <Item Id="336" Name="Bathtub" />
-    <Item Id="337" Name="Red Banner" />
-    <Item Id="338" Name="Green Banner" />
-    <Item Id="339" Name="Blue Banner" />
-    <Item Id="340" Name="Yellow Banner" />
-    <Item Id="341" Name="Lamp Post" />
-    <Item Id="342" Name="Tiki Torch" />
-    <Item Id="343" Name="Barrel" />
-    <Item Id="344" Name="Chinese Lantern" />
-    <Item Id="345" Name="Cooking Pot" />
-    <Item Id="346" Name="Safe" />
-    <Item Id="347" Name="Skull Lantern" />
-    <Item Id="348" Name="Trash Can" />
-    <Item Id="349" Name="Candelabra" />
-    <Item Id="350" Name="Pink Vase" />
-    <Item Id="351" Name="Mug" />
-    <Item Id="352" Name="Keg" />
-    <Item Id="353" Name="Ale" />
-    <Item Id="354" Name="Bookcase" />
-    <Item Id="355" Name="Throne" />
-    <Item Id="356" Name="Bowl" />
-    <Item Id="357" Name="Bowl of Soup" />
-    <Item Id="358" Name="Toilet" />
-    <Item Id="359" Name="Grandfather Clock" />
-    <Item Id="360" Name="Armor Statue" />
-    <Item Id="361" Name="Goblin Battle Standard" />
-    <Item Id="362" Name="Tattered Cloth" />
-    <Item Id="363" Name="Sawmill" />
-    <Item Id="364" Name="Cobalt Ore" />
-    <Item Id="365" Name="Mythril Ore" />
-    <Item Id="366" Name="Adamantite Ore" />
-    <Item Id="367" Name="Pwnhammer" Scale="1.2" Rack="true" />
-    <Item Id="368" Name="Excalibur" Scale="1.15" Rack="true" />
-    <Item Id="369" Name="Hallowed Seeds" />
-    <Item Id="370" Name="Ebonsand Block" />
-    <Item Id="371" Name="Cobalt Hat" Head="29" />
-    <Item Id="372" Name="Cobalt Helmet" Head="30" />
-    <Item Id="373" Name="Cobalt Mask" Head="31" />
-    <Item Id="374" Name="Cobalt Breastplate" Body="17" />
-    <Item Id="375" Name="Cobalt Leggings" Legs="16" />
-    <Item Id="376" Name="Mythril Hood" Head="32" />
-    <Item Id="377" Name="Mythril Helmet" Head="33" />
-    <Item Id="378" Name="Mythril Hat" Head="34" />
-    <Item Id="379" Name="Mythril Chainmail" Body="18" />
-    <Item Id="380" Name="Mythril Greaves" Legs="17" />
-    <Item Id="381" Name="Cobalt Bar" />
-    <Item Id="382" Name="Mythril Bar" />
-    <Item Id="383" Name="Cobalt Chainsaw" Rack="true" />
-    <Item Id="384" Name="Mythril Chainsaw" Rack="true" />
-    <Item Id="385" Name="Cobalt Drill" Rack="true" />
-    <Item Id="386" Name="Mythril Drill" Rack="true" />
-    <Item Id="387" Name="Adamantite Chainsaw" Rack="true" />
-    <Item Id="388" Name="Adamantite Drill" Rack="true" />
-    <Item Id="389" Name="Dao of Pow" Scale="1.1" Rack="true" />
-    <Item Id="390" Name="Mythril Halberd" Scale="1.1" Rack="true" />
-    <Item Id="391" Name="Adamantite Bar" />
-    <Item Id="392" Name="Glass Wall" />
-    <Item Id="393" Name="Compass" />
-    <Item Id="394" Name="Diving Gear" />
-    <Item Id="395" Name="GPS" />
-    <Item Id="396" Name="Obsidian Horseshoe" />
-    <Item Id="397" Name="Obsidian Shield" />
-    <Item Id="398" Name="Tinkerer's Workshop" />
-    <Item Id="399" Name="Cloud in a Balloon" />
-    <Item Id="400" Name="Adamantite Headgear" Head="35" />
-    <Item Id="401" Name="Adamantite Helmet" Head="36" />
-    <Item Id="402" Name="Adamantite Mask" Head="37" />
-    <Item Id="403" Name="Adamantite Breastplate" Body="19" />
-    <Item Id="404" Name="Adamantite Leggings" Legs="18" />
-    <Item Id="405" Name="Spectre Boots" />
-    <Item Id="406" Name="Adamantite Glaive" Scale="1.1" Rack="true" />
-    <Item Id="407" Name="Toolbelt" />
-    <Item Id="408" Name="Pearlsand Block" />
-    <Item Id="409" Name="Pearlstone Block" />
-    <Item Id="410" Name="Mining Shirt" Body="20" />
-    <Item Id="411" Name="Mining Pants" Legs="19" />
-    <Item Id="412" Name="Pearlstone Brick" />
-    <Item Id="413" Name="Iridescent Brick" />
+    <Item Id="1" Name="铁镐" Rack="true" />
+    <Item Id="2" Name="土块" />
+    <Item Id="3" Name="石块" />
+    <Item Id="4" Name="铁阔剑" Rack="true" />
+    <Item Id="5" Name="蘑菇" />
+    <Item Id="6" Name="铁短剑" Scale="0.9" Rack="true" />
+    <Item Id="7" Name="铁锤" Scale="1.2" Rack="true" />
+    <Item Id="8" Name="火把" />
+    <Item Id="9" Name="木材" />
+    <Item Id="10" Name="铁斧" Scale="1.1" Rack="true" />
+    <Item Id="11" Name="铁矿" />
+    <Item Id="12" Name="铜矿" />
+    <Item Id="13" Name="金矿" />
+    <Item Id="14" Name="银矿" />
+    <Item Id="15" Name="铜表" />
+    <Item Id="16" Name="银表" />
+    <Item Id="17" Name="金表" />
+    <Item Id="18" Name="深度计" />
+    <Item Id="19" Name="金锭" />
+    <Item Id="20" Name="铜锭" />
+    <Item Id="21" Name="银锭" />
+    <Item Id="22" Name="铁锭" />
+    <Item Id="23" Name="凝胶" />
+    <Item Id="24" Name="木剑" Scale="0.95" Rack="true" />
+    <Item Id="25" Name="木门" />
+    <Item Id="26" Name="石墙" />
+    <Item Id="27" Name="橡实" />
+    <Item Id="28" Name="弱效治疗药水" />
+    <Item Id="29" Name="生命水晶" />
+    <Item Id="30" Name="土墙" />
+    <Item Id="31" Name="玻璃瓶" />
+    <Item Id="32" Name="木桌" />
+    <Item Id="33" Name="熔炉" />
+    <Item Id="34" Name="木椅" />
+    <Item Id="35" Name="铁砧" />
+    <Item Id="36" Name="工作台" />
+    <Item Id="37" Name="护目镜" Head="10" />
+    <Item Id="38" Name="晶状体" />
+    <Item Id="39" Name="木弓" Rack="true" />
+    <Item Id="40" Name="木箭" Rack="true" />
+    <Item Id="41" Name="烈焰箭" Rack="true" />
+    <Item Id="42" Name="手里剑" Rack="true" />
+    <Item Id="43" Name="可疑眼球" />
+    <Item Id="44" Name="恶魔弓" Rack="true" />
+    <Item Id="45" Name="暗夜战斧" Scale="1.2" Rack="true" />
+    <Item Id="46" Name="魔光剑" Scale="1.1" Rack="true" />
+    <Item Id="47" Name="邪箭" Rack="true" />
+    <Item Id="48" Name="宝箱" />
+    <Item Id="49" Name="再生手环" />
+    <Item Id="50" Name="魔镜" />
+    <Item Id="51" Name="小丑之箭" Rack="true" />
+    <Item Id="52" Name="天使雕像" />
+    <Item Id="53" Name="云朵瓶" />
+    <Item Id="54" Name="赫尔墨斯靴" />
+    <Item Id="55" Name="附魔回旋镖" Rack="true" />
+    <Item Id="56" Name="魔矿" />
+    <Item Id="57" Name="魔矿锭" />
+    <Item Id="58" Name="心" />
+    <Item Id="59" Name="腐化种子" />
+    <Item Id="60" Name="魔菇" />
+    <Item Id="61" Name="黑檀石块" />
+    <Item Id="62" Name="草种子" />
+    <Item Id="63" Name="向日葵" />
+    <Item Id="64" Name="魔刺" Rack="true" />
+    <Item Id="65" Name="星怒" Scale="1.25" Rack="true" />
+    <Item Id="66" Name="净化粉" />
+    <Item Id="67" Name="魔粉" />
+    <Item Id="68" Name="腐肉" />
+    <Item Id="69" Name="蠕虫毒牙" />
+    <Item Id="70" Name="蠕虫诱饵" />
+    <Item Id="71" Name="铜币" Rack="true" />
+    <Item Id="72" Name="银币" Rack="true" />
+    <Item Id="73" Name="金币" Rack="true" />
+    <Item Id="74" Name="铂金币" Rack="true" />
+    <Item Id="75" Name="坠落之星" />
+    <Item Id="76" Name="铜护胫" Legs="1" />
+    <Item Id="77" Name="铁护胫" Legs="2" />
+    <Item Id="78" Name="银护胫" Legs="3" />
+    <Item Id="79" Name="金护胫" Legs="4" />
+    <Item Id="80" Name="铜链甲" Body="1" />
+    <Item Id="81" Name="铁链甲" Body="2" />
+    <Item Id="82" Name="银链甲" Body="3" />
+    <Item Id="83" Name="金链甲" Body="4" />
+    <Item Id="84" Name="抓钩" />
+    <Item Id="85" Name="链条" />
+    <Item Id="86" Name="暗影鳞片" />
+    <Item Id="87" Name="猪猪存钱罐" />
+    <Item Id="88" Name="挖矿头盔" Head="11" />
+    <Item Id="89" Name="铜头盔" Head="1" />
+    <Item Id="90" Name="铁头盔" Head="2" />
+    <Item Id="91" Name="银头盔" Head="3" />
+    <Item Id="92" Name="金头盔" Head="4" />
+    <Item Id="93" Name="木墙" />
+    <Item Id="94" Name="木平台" />
+    <Item Id="95" Name="燧发枪" Scale="0.9" Rack="true" />
+    <Item Id="96" Name="火枪" Rack="true" />
+    <Item Id="97" Name="火枪子弹" Rack="true" />
+    <Item Id="98" Name="迷你鲨" Rack="true" />
+    <Item Id="99" Name="铁弓" Rack="true" />
+    <Item Id="100" Name="暗影护胫" Legs="5" />
+    <Item Id="101" Name="暗影鳞甲" Body="5" />
+    <Item Id="102" Name="暗影头盔" Head="5" />
+    <Item Id="103" Name="梦魇镐" Scale="1.15" Rack="true" />
+    <Item Id="104" Name="魔锤" Scale="1.3" Rack="true" />
+    <Item Id="105" Name="蜡烛" />
+    <Item Id="106" Name="铜吊灯" />
+    <Item Id="107" Name="银吊灯" />
+    <Item Id="108" Name="金吊灯" />
+    <Item Id="109" Name="魔力水晶" />
+    <Item Id="110" Name="弱效魔力药水" />
+    <Item Id="111" Name="星力手环" />
+    <Item Id="112" Name="火之花" Rack="true" />
+    <Item Id="113" Name="魔法导弹" Rack="true" />
+    <Item Id="114" Name="土魔杖" />
+    <Item Id="115" Name="暗影珠" Rack="true" />
+    <Item Id="116" Name="陨石" />
+    <Item Id="117" Name="陨石锭" />
+    <Item Id="118" Name="爪钩" />
+    <Item Id="119" Name="烈焰回旋镖" Rack="true" />
+    <Item Id="120" Name="熔火之怒" Scale="1.1" Rack="true" />
+    <Item Id="121" Name="炽焰巨剑" Scale="1.3" Rack="true" />
+    <Item Id="122" Name="熔岩镐" Scale="1.15" Rack="true" />
+    <Item Id="123" Name="流星头盔" Head="6" />
+    <Item Id="124" Name="流星护甲" Body="6" />
+    <Item Id="125" Name="流星护腿" Legs="6" />
+    <Item Id="126" Name="水瓶" />
+    <Item Id="127" Name="太空枪" Scale="0.8" Rack="true" />
+    <Item Id="128" Name="火箭靴" />
+    <Item Id="129" Name="灰砖" />
+    <Item Id="130" Name="灰砖墙" />
+    <Item Id="131" Name="红砖" />
+    <Item Id="132" Name="红砖墙" />
+    <Item Id="133" Name="粘土块" />
+    <Item Id="134" Name="蓝砖" />
+    <Item Id="135" Name="蓝砖墙" />
+    <Item Id="136" Name="挂链灯笼" />
+    <Item Id="137" Name="绿砖" />
+    <Item Id="138" Name="绿砖墙" />
+    <Item Id="139" Name="粉砖" />
+    <Item Id="140" Name="粉砖墙" />
+    <Item Id="141" Name="金砖" />
+    <Item Id="142" Name="金砖墙" />
+    <Item Id="143" Name="银砖" />
+    <Item Id="144" Name="银砖墙" />
+    <Item Id="145" Name="铜砖" />
+    <Item Id="146" Name="铜砖墙" />
+    <Item Id="147" Name="尖刺" />
+    <Item Id="148" Name="水蜡烛" />
+    <Item Id="149" Name="书" />
+    <Item Id="150" Name="蛛网" />
+    <Item Id="151" Name="死灵头盔" Head="7" />
+    <Item Id="152" Name="死灵胸甲" Body="7" />
+    <Item Id="153" Name="死灵护胫" Legs="7" />
+    <Item Id="154" Name="骨头" Rack="true" />
+    <Item Id="155" Name="村正大刀" Scale="1.1" Rack="true" />
+    <Item Id="156" Name="钴护盾" />
+    <Item Id="157" Name="海蓝权杖" Rack="true" />
+    <Item Id="158" Name="幸运马掌" />
+    <Item Id="159" Name="闪亮红气球" />
+    <Item Id="160" Name="鱼叉枪" Scale="1.1" Rack="true" />
+    <Item Id="161" Name="尖球" Rack="true" />
+    <Item Id="162" Name="链球" Scale="1.1" Rack="true" />
+    <Item Id="163" Name="蓝月" Scale="1.1" Rack="true" />
+    <Item Id="164" Name="手枪" Scale="0.85" Rack="true" />
+    <Item Id="165" Name="水矢" Scale="0.9" Rack="true" />
+    <Item Id="166" Name="炸弹" />
+    <Item Id="167" Name="雷管" />
+    <Item Id="168" Name="手榴弹" Rack="true" />
+    <Item Id="169" Name="沙块" />
+    <Item Id="170" Name="玻璃" />
+    <Item Id="171" Name="标牌" />
+    <Item Id="172" Name="灰烬块" />
+    <Item Id="173" Name="黑曜石" />
+    <Item Id="174" Name="狱石" />
+    <Item Id="175" Name="狱石锭" />
+    <Item Id="176" Name="泥块" />
+    <Item Id="177" Name="蓝玉" />
+    <Item Id="178" Name="红玉" />
+    <Item Id="179" Name="翡翠" />
+    <Item Id="180" Name="黄玉" />
+    <Item Id="181" Name="紫晶" />
+    <Item Id="182" Name="钻石" />
+    <Item Id="183" Name="发光蘑菇" />
+    <Item Id="184" Name="星星" />
+    <Item Id="185" Name="常春藤鞭" Rack="true" />
+    <Item Id="186" Name="芦苇呼吸管" />
+    <Item Id="187" Name="脚蹼" />
+    <Item Id="188" Name="治疗药水" />
+    <Item Id="189" Name="魔力药水" />
+    <Item Id="190" Name="草剑" Scale="1.4" Rack="true" />
+    <Item Id="191" Name="荆棘旋刃" Rack="true" />
+    <Item Id="192" Name="黑曜石砖" />
+    <Item Id="193" Name="黑曜石骷髅头" />
+    <Item Id="194" Name="蘑菇草种子" />
+    <Item Id="195" Name="丛林草种子" />
+    <Item Id="196" Name="木锤" Scale="1.2" Rack="true" />
+    <Item Id="197" Name="星星炮" Rack="true" />
+    <Item Id="198" Name="蓝陨石光剑" Rack="true" />
+    <Item Id="199" Name="红陨石光剑" Rack="true" />
+    <Item Id="200" Name="绿陨石光剑" Rack="true" />
+    <Item Id="201" Name="紫陨石光剑" Rack="true" />
+    <Item Id="202" Name="白陨石光剑" Rack="true" />
+    <Item Id="203" Name="黄陨石光剑" Rack="true" />
+    <Item Id="204" Name="流星锤斧" Scale="1.2" Rack="true" />
+    <Item Id="205" Name="空桶" Head="13" />
+    <Item Id="206" Name="水桶" />
+    <Item Id="207" Name="熔岩桶" />
+    <Item Id="208" Name="丛林玫瑰" Head="23" />
+    <Item Id="209" Name="毒刺" />
+    <Item Id="210" Name="藤蔓" />
+    <Item Id="211" Name="猛爪手套" />
+    <Item Id="212" Name="疾风脚镯" />
+    <Item Id="213" Name="再生法杖" Rack="true" />
+    <Item Id="214" Name="狱石砖" />
+    <Item Id="215" Name="整蛊坐垫" />
+    <Item Id="216" Name="脚镣" />
+    <Item Id="217" Name="熔岩锤斧" Scale="1.4" Rack="true" />
+    <Item Id="218" Name="烈焰火鞭" Rack="true" />
+    <Item Id="219" Name="凤凰爆破枪" Scale="0.85" Rack="true" />
+    <Item Id="220" Name="阳炎之怒" Scale="1.1" Rack="true" />
+    <Item Id="221" Name="地狱熔炉" />
+    <Item Id="222" Name="粘土盆" />
+    <Item Id="223" Name="大自然的恩赐" />
+    <Item Id="224" Name="床" />
+    <Item Id="225" Name="丝绸" />
+    <Item Id="226" Name="弱效恢复药水" />
+    <Item Id="227" Name="恢复药水" />
+    <Item Id="228" Name="丛林帽" Head="8" />
+    <Item Id="229" Name="丛林衣" Body="8" />
+    <Item Id="230" Name="丛林裤" Legs="8" />
+    <Item Id="231" Name="熔岩头盔" Head="9" />
+    <Item Id="232" Name="熔岩胸甲" Body="9" />
+    <Item Id="233" Name="熔岩护胫" Legs="9" />
+    <Item Id="234" Name="流星弹" Rack="true" />
+    <Item Id="235" Name="粘性炸弹" />
+    <Item Id="236" Name="黑晶状体" />
+    <Item Id="237" Name="墨镜" Head="12" />
+    <Item Id="238" Name="巫师帽" Head="14" />
+    <Item Id="239" Name="高顶礼帽" Head="15" />
+    <Item Id="240" Name="西装衣" Body="10" />
+    <Item Id="241" Name="西装裤" Legs="10" />
+    <Item Id="242" Name="夏日草帽" Head="16" />
+    <Item Id="243" Name="兔兔兜帽" Head="17" />
+    <Item Id="244" Name="管道工帽" Head="18" />
+    <Item Id="245" Name="管道工衣" Body="11" />
+    <Item Id="246" Name="管道工背带裤" Legs="11" />
+    <Item Id="247" Name="英雄帽" Head="19" />
+    <Item Id="248" Name="英雄衣" Body="12" />
+    <Item Id="249" Name="英雄裤" Legs="12" />
+    <Item Id="250" Name="鱼缸" Head="20" />
+    <Item Id="251" Name="考古帽" Head="21" />
+    <Item Id="252" Name="考古夹克" Body="13" />
+    <Item Id="253" Name="考古裤" Legs="13" />
+    <Item Id="254" Name="黑线" />
+    <Item Id="255" Name="绿线" />
+    <Item Id="256" Name="忍者兜帽" Head="22" />
+    <Item Id="257" Name="忍者衣" Body="14" />
+    <Item Id="258" Name="忍者裤" Legs="14" />
+    <Item Id="259" Name="皮革" />
+    <Item Id="260" Name="红帽" Head="24" />
+    <Item Id="261" Name="金鱼" />
+    <Item Id="262" Name="长袍" Body="15" />
+    <Item Id="263" Name="机器人帽" Head="25" />
+    <Item Id="264" Name="金冠" Head="26" />
+    <Item Id="265" Name="狱炎箭" Rack="true" />
+    <Item Id="266" Name="沙枪" Rack="true" />
+    <Item Id="267" Name="向导巫毒娃娃" />
+    <Item Id="268" Name="潜水头盔" Head="27" />
+    <Item Id="269" Name="便装衣" />
+    <Item Id="270" Name="便装裤" />
+    <Item Id="271" Name="便装假发" />
+    <Item Id="272" Name="恶魔锄刀" Scale="0.9" Rack="true" />
+    <Item Id="273" Name="永夜刃" Scale="1.15" Rack="true" />
+    <Item Id="274" Name="暗黑长戟" Scale="1.1" Rack="true" />
+    <Item Id="275" Name="珊瑚" />
+    <Item Id="276" Name="仙人掌" />
+    <Item Id="277" Name="三叉戟" Scale="1.1" Rack="true" />
+    <Item Id="278" Name="银子弹" Rack="true" />
+    <Item Id="279" Name="投刀" Rack="true" />
+    <Item Id="280" Name="长矛" Rack="true" />
+    <Item Id="281" Name="吹管" Rack="true" />
+    <Item Id="282" Name="荧光棒" />
+    <Item Id="283" Name="种子" Rack="true" />
+    <Item Id="284" Name="木制回旋镖" Rack="true" />
+    <Item Id="285" Name="金属带扣" />
+    <Item Id="286" Name="粘性荧光棒" />
+    <Item Id="287" Name="毒刀" Rack="true" />
+    <Item Id="288" Name="黑曜石皮药水" />
+    <Item Id="289" Name="再生药水" />
+    <Item Id="290" Name="敏捷药水" />
+    <Item Id="291" Name="鱼鳃药水" />
+    <Item Id="292" Name="铁皮药水" />
+    <Item Id="293" Name="魔力再生药水" />
+    <Item Id="294" Name="魔能药水" />
+    <Item Id="295" Name="羽落药水" />
+    <Item Id="296" Name="洞穴探险药水" />
+    <Item Id="297" Name="隐身药水" />
+    <Item Id="298" Name="光芒药水" />
+    <Item Id="299" Name="夜猫子药水" />
+    <Item Id="300" Name="战斗药水" />
+    <Item Id="301" Name="荆棘药水" />
+    <Item Id="302" Name="水上漂药水" />
+    <Item Id="303" Name="箭术药水" />
+    <Item Id="304" Name="狩猎药水" />
+    <Item Id="305" Name="重力药水" />
+    <Item Id="306" Name="金箱" />
+    <Item Id="307" Name="太阳花种子" />
+    <Item Id="308" Name="月光草种子" />
+    <Item Id="309" Name="闪耀根种子" />
+    <Item Id="310" Name="死亡草种子" />
+    <Item Id="311" Name="幌菊种子" />
+    <Item Id="312" Name="火焰花种子" />
+    <Item Id="313" Name="太阳花" />
+    <Item Id="314" Name="月光草" />
+    <Item Id="315" Name="闪耀根" />
+    <Item Id="316" Name="死亡草" />
+    <Item Id="317" Name="幌菊" />
+    <Item Id="318" Name="火焰花" />
+    <Item Id="319" Name="鲨鱼鳍" />
+    <Item Id="320" Name="羽毛" />
+    <Item Id="321" Name="墓石" />
+    <Item Id="322" Name="丑角面具" Head="28" />
+    <Item Id="323" Name="蚁狮上颚" />
+    <Item Id="324" Name="非法枪械部件" />
+    <Item Id="325" Name="博士衣" Body="16" />
+    <Item Id="326" Name="博士裤" Legs="15" />
+    <Item Id="327" Name="金钥匙" />
+    <Item Id="328" Name="暗影箱" />
+    <Item Id="329" Name="暗影钥匙" />
+    <Item Id="330" Name="黑曜石砖墙" />
+    <Item Id="331" Name="丛林孢子" />
+    <Item Id="332" Name="织布机" />
+    <Item Id="333" Name="钢琴" />
+    <Item Id="334" Name="梳妆台" />
+    <Item Id="335" Name="长椅" />
+    <Item Id="336" Name="浴缸" />
+    <Item Id="337" Name="红旗" />
+    <Item Id="338" Name="绿旗" />
+    <Item Id="339" Name="蓝旗" />
+    <Item Id="340" Name="黄旗" />
+    <Item Id="341" Name="灯柱" />
+    <Item Id="342" Name="提基火把" />
+    <Item Id="343" Name="桶" />
+    <Item Id="344" Name="中式灯笼" />
+    <Item Id="345" Name="烹饪锅" />
+    <Item Id="346" Name="保险箱" />
+    <Item Id="347" Name="骷髅头灯笼" />
+    <Item Id="348" Name="垃圾桶" />
+    <Item Id="349" Name="烛台" />
+    <Item Id="350" Name="粉花瓶" />
+    <Item Id="351" Name="玻璃杯" />
+    <Item Id="352" Name="酒桶" />
+    <Item Id="353" Name="麦芽酒" />
+    <Item Id="354" Name="书架" />
+    <Item Id="355" Name="王座" />
+    <Item Id="356" Name="碗" />
+    <Item Id="357" Name="鱼菇汤" />
+    <Item Id="358" Name="马桶" />
+    <Item Id="359" Name="落地大摆钟" />
+    <Item Id="360" Name="盔甲雕像" />
+    <Item Id="361" Name="哥布林战旗" />
+    <Item Id="362" Name="破布" />
+    <Item Id="363" Name="锯木机" />
+    <Item Id="364" Name="钴矿" />
+    <Item Id="365" Name="秘银矿" />
+    <Item Id="366" Name="精金矿" />
+    <Item Id="367" Name="神锤" Scale="1.2" Rack="true" />
+    <Item Id="368" Name="断钢剑" Scale="1.15" Rack="true" />
+    <Item Id="369" Name="圣种" />
+    <Item Id="370" Name="黑檀沙块" />
+    <Item Id="371" Name="钴帽" Head="29" />
+    <Item Id="372" Name="钴头盔" Head="30" />
+    <Item Id="373" Name="钴面具" Head="31" />
+    <Item Id="374" Name="钴胸甲" Body="17" />
+    <Item Id="375" Name="钴护腿" Legs="16" />
+    <Item Id="376" Name="秘银兜帽" Head="32" />
+    <Item Id="377" Name="秘银头盔" Head="33" />
+    <Item Id="378" Name="秘银帽" Head="34" />
+    <Item Id="379" Name="秘银链甲" Body="18" />
+    <Item Id="380" Name="秘银护胫" Legs="17" />
+    <Item Id="381" Name="钴锭" />
+    <Item Id="382" Name="秘银锭" />
+    <Item Id="383" Name="钴链锯" Rack="true" />
+    <Item Id="384" Name="秘银链锯" Rack="true" />
+    <Item Id="385" Name="钴钻头" Rack="true" />
+    <Item Id="386" Name="秘银钻头" Rack="true" />
+    <Item Id="387" Name="精金链锯" Rack="true" />
+    <Item Id="388" Name="精金钻头" Rack="true" />
+    <Item Id="389" Name="太极连枷" Scale="1.1" Rack="true" />
+    <Item Id="390" Name="秘银长戟" Scale="1.1" Rack="true" />
+    <Item Id="391" Name="精金锭" />
+    <Item Id="392" Name="玻璃墙" />
+    <Item Id="393" Name="罗盘" />
+    <Item Id="394" Name="潜水装备" />
+    <Item Id="395" Name="全球定位系统" />
+    <Item Id="396" Name="黑曜石马掌" />
+    <Item Id="397" Name="黑曜石护盾" />
+    <Item Id="398" Name="工匠作坊" />
+    <Item Id="399" Name="云朵气球" />
+    <Item Id="400" Name="精金头饰" Head="35" />
+    <Item Id="401" Name="精金头盔" Head="36" />
+    <Item Id="402" Name="精金面具" Head="37" />
+    <Item Id="403" Name="精金胸甲" Body="19" />
+    <Item Id="404" Name="精金护腿" Legs="18" />
+    <Item Id="405" Name="幽灵靴" />
+    <Item Id="406" Name="精金关刀" Scale="1.1" Rack="true" />
+    <Item Id="407" Name="工具腰带" />
+    <Item Id="408" Name="珍珠沙块" />
+    <Item Id="409" Name="珍珠石块" />
+    <Item Id="410" Name="挖矿衣" Body="20" />
+    <Item Id="411" Name="挖矿裤" Legs="19" />
+    <Item Id="412" Name="珍珠石砖" />
+    <Item Id="413" Name="荧光砖" />
     <Item Id="414" Name="Mudstone Block" />
-    <Item Id="415" Name="Cobalt Brick" />
-    <Item Id="416" Name="Mythril Brick" />
-    <Item Id="417" Name="Pearlstone Brick Wall" />
-    <Item Id="418" Name="Iridescent Brick Wall" />
-    <Item Id="419" Name="Mudstone Brick Wall" />
-    <Item Id="420" Name="Cobalt Brick Wall" />
-    <Item Id="421" Name="Mythril Brick Wall" />
-    <Item Id="422" Name="Holy Water" Rack="true" />
-    <Item Id="423" Name="Unholy Water" Rack="true" />
-    <Item Id="424" Name="Silt Block" />
-    <Item Id="425" Name="Fairy Bell" Rack="true" />
-    <Item Id="426" Name="Breaker Blade" Scale="1.05" Rack="true" />
-    <Item Id="427" Name="Blue Torch" />
-    <Item Id="428" Name="Red Torch" />
-    <Item Id="429" Name="Green Torch" />
-    <Item Id="430" Name="Purple Torch" />
-    <Item Id="431" Name="White Torch" />
-    <Item Id="432" Name="Yellow Torch" />
-    <Item Id="433" Name="Demon Torch" />
-    <Item Id="434" Name="Clockwork Assault Rifle" Rack="true" />
-    <Item Id="435" Name="Cobalt Repeater" Rack="true" />
-    <Item Id="436" Name="Mythril Repeater" Rack="true" />
-    <Item Id="437" Name="Dual Hook" />
-    <Item Id="438" Name="Star Statue" />
-    <Item Id="439" Name="Sword Statue" />
-    <Item Id="440" Name="Slime Statue" />
-    <Item Id="441" Name="Goblin Statue" />
-    <Item Id="442" Name="Shield Statue" />
-    <Item Id="443" Name="Bat Statue" />
-    <Item Id="444" Name="Fish Statue" />
-    <Item Id="445" Name="Bunny Statue" />
-    <Item Id="446" Name="Skeleton Statue" />
-    <Item Id="447" Name="Reaper Statue" />
-    <Item Id="448" Name="Woman Statue" />
-    <Item Id="449" Name="Imp Statue" />
-    <Item Id="450" Name="Gargoyle Statue" />
-    <Item Id="451" Name="Gloom Statue" />
-    <Item Id="452" Name="Hornet Statue" />
-    <Item Id="453" Name="Bomb Statue" />
-    <Item Id="454" Name="Crab Statue" />
-    <Item Id="455" Name="Hammer Statue" />
-    <Item Id="456" Name="Potion Statue" />
-    <Item Id="457" Name="Spear Statue" />
-    <Item Id="458" Name="Cross Statue" />
-    <Item Id="459" Name="Jellyfish Statue" />
-    <Item Id="460" Name="Bow Statue" />
-    <Item Id="461" Name="Boomerang Statue" />
-    <Item Id="462" Name="Boot Statue" />
-    <Item Id="463" Name="Chest Statue" />
-    <Item Id="464" Name="Bird Statue" />
-    <Item Id="465" Name="Axe Statue" />
-    <Item Id="466" Name="Corrupt Statue" />
-    <Item Id="467" Name="Tree Statue" />
-    <Item Id="468" Name="Anvil Statue" />
-    <Item Id="469" Name="Pickaxe Statue" />
-    <Item Id="470" Name="Mushroom Statue" />
-    <Item Id="471" Name="Eyeball Statue" />
-    <Item Id="472" Name="Pillar Statue" />
-    <Item Id="473" Name="Heart Statue" />
-    <Item Id="474" Name="Pot Statue" />
-    <Item Id="475" Name="Sunflower Statue" />
-    <Item Id="476" Name="King Statue" />
-    <Item Id="477" Name="Queen Statue" />
-    <Item Id="478" Name="Piranha Statue" />
-    <Item Id="479" Name="Planked Wall" />
-    <Item Id="480" Name="Wooden Beam" />
-    <Item Id="481" Name="Adamantite Repeater" Rack="true" />
-    <Item Id="482" Name="Adamantite Sword" Scale="1.2" Rack="true" />
-    <Item Id="483" Name="Cobalt Sword" Scale="1.1" Rack="true" />
-    <Item Id="484" Name="Mythril Sword" Scale="1.15" Rack="true" />
-    <Item Id="485" Name="Moon Charm" />
-    <Item Id="486" Name="Ruler" />
-    <Item Id="487" Name="Crystal Ball" />
-    <Item Id="488" Name="Disco Ball" />
-    <Item Id="489" Name="Sorcerer Emblem" />
-    <Item Id="490" Name="Warrior Emblem" />
-    <Item Id="491" Name="Ranger Emblem" />
-    <Item Id="492" Name="Demon Wings" />
-    <Item Id="493" Name="Angel Wings" />
-    <Item Id="494" Name="Magical Harp" Rack="true" />
-    <Item Id="495" Name="Rainbow Rod" Rack="true" />
-    <Item Id="496" Name="Ice Rod" Rack="true" />
-    <Item Id="497" Name="Neptune's Shell" />
-    <Item Id="498" Name="Mannequin" />
-    <Item Id="499" Name="Greater Healing Potion" />
-    <Item Id="500" Name="Greater Mana Potion" />
-    <Item Id="501" Name="Pixie Dust" />
-    <Item Id="502" Name="Crystal Shard" />
-    <Item Id="503" Name="Clown Hat" Head="40" />
-    <Item Id="504" Name="Clown Shirt" Body="23" />
-    <Item Id="505" Name="Clown Pants" Legs="22" />
-    <Item Id="506" Name="Flamethrower" Rack="true" />
-    <Item Id="507" Name="Bell" />
-    <Item Id="508" Name="Harp" />
-    <Item Id="509" Name="Wrench" />
-    <Item Id="510" Name="Wire Cutter" />
-    <Item Id="511" Name="Active Stone Block" />
-    <Item Id="512" Name="Inactive Stone Block" />
-    <Item Id="513" Name="Lever" />
-    <Item Id="514" Name="Laser Rifle" Rack="true" />
-    <Item Id="515" Name="Crystal Bullet" Rack="true" />
-    <Item Id="516" Name="Holy Arrow" Rack="true" />
-    <Item Id="517" Name="Magic Dagger" Rack="true" />
-    <Item Id="518" Name="Crystal Storm" Scale="0.9" Rack="true" />
-    <Item Id="519" Name="Cursed Flames" Scale="0.9" Rack="true" />
-    <Item Id="520" Name="Soul of Light" />
-    <Item Id="521" Name="Soul of Night" />
-    <Item Id="522" Name="Cursed Flame" />
-    <Item Id="523" Name="Cursed Torch" />
-    <Item Id="524" Name="Adamantite Forge" />
-    <Item Id="525" Name="Mythril Anvil" />
-    <Item Id="526" Name="Unicorn Horn" />
-    <Item Id="527" Name="Dark Shard" />
-    <Item Id="528" Name="Light Shard" />
-    <Item Id="529" Name="Red Pressure Plate" />
-    <Item Id="530" Name="Wire" />
-    <Item Id="531" Name="Spell Tome" />
-    <Item Id="532" Name="Star Cloak" />
-    <Item Id="533" Name="Megashark" Rack="true" />
-    <Item Id="534" Name="Shotgun" Rack="true" />
-    <Item Id="535" Name="Philosopher's Stone" />
-    <Item Id="536" Name="Titan Glove" />
-    <Item Id="537" Name="Cobalt Naginata" Scale="1.1" Rack="true" />
-    <Item Id="538" Name="Switch" />
-    <Item Id="539" Name="Dart Trap" />
-    <Item Id="540" Name="Boulder" />
-    <Item Id="541" Name="Green Pressure Plate" />
-    <Item Id="542" Name="Gray Pressure Plate" />
-    <Item Id="543" Name="Brown Pressure Plate" />
-    <Item Id="544" Name="Mechanical Eye" />
-    <Item Id="545" Name="Cursed Arrow" Rack="true" />
-    <Item Id="546" Name="Cursed Bullet" Rack="true" />
-    <Item Id="547" Name="Soul of Fright" />
-    <Item Id="548" Name="Soul of Might" />
-    <Item Id="549" Name="Soul of Sight" />
-    <Item Id="550" Name="Gungnir" Scale="1.1" Rack="true" />
-    <Item Id="551" Name="Hallowed Plate Mail" Body="24" />
-    <Item Id="552" Name="Hallowed Greaves" Legs="23" />
-    <Item Id="553" Name="Hallowed Helmet" Head="41" />
-    <Item Id="554" Name="Cross Necklace" />
-    <Item Id="555" Name="Mana Flower" />
-    <Item Id="556" Name="Mechanical Worm" />
-    <Item Id="557" Name="Mechanical Skull" />
-    <Item Id="558" Name="Hallowed Headgear" Head="42" />
-    <Item Id="559" Name="Hallowed Mask" Head="43" />
-    <Item Id="560" Name="Slime Crown" />
-    <Item Id="561" Name="Light Disc" Rack="true" />
-    <Item Id="562" Name="Music Box (Overworld Day)" />
-    <Item Id="563" Name="Music Box (Eerie)" />
-    <Item Id="564" Name="Music Box (Night)" />
-    <Item Id="565" Name="Music Box (Title)" />
-    <Item Id="566" Name="Music Box (Underground)" />
-    <Item Id="567" Name="Music Box (Boss 1)" />
-    <Item Id="568" Name="Music Box (Jungle)" />
-    <Item Id="569" Name="Music Box (Corruption)" />
-    <Item Id="570" Name="Music Box (Underground Corruption)" />
-    <Item Id="571" Name="Music Box (The Hallow)" />
-    <Item Id="572" Name="Music Box (Boss 2)" />
-    <Item Id="573" Name="Music Box (Underground Hallow)" />
-    <Item Id="574" Name="Music Box (Boss 3)" />
-    <Item Id="575" Name="Soul of Flight" />
-    <Item Id="576" Name="Music Box" />
-    <Item Id="577" Name="Demonite Brick" />
-    <Item Id="578" Name="Hallowed Repeater" Rack="true" />
-    <Item Id="579" Name="Drax" Rack="true" />
-    <Item Id="580" Name="Explosives" />
-    <Item Id="581" Name="Inlet Pump" />
-    <Item Id="582" Name="Outlet Pump" />
-    <Item Id="583" Name="1 Second Timer" />
-    <Item Id="584" Name="3 Second Timer" />
-    <Item Id="585" Name="5 Second Timer" />
-    <Item Id="586" Name="Candy Cane Block" />
-    <Item Id="587" Name="Candy Cane Wall" />
-    <Item Id="588" Name="Santa Hat" Head="44" />
-    <Item Id="589" Name="Santa Shirt" Body="25" />
-    <Item Id="590" Name="Santa Pants" Legs="24" />
-    <Item Id="591" Name="Green Candy Cane Block" />
-    <Item Id="592" Name="Green Candy Cane Wall" />
-    <Item Id="593" Name="Snow Block" />
-    <Item Id="594" Name="Snow Brick" />
-    <Item Id="595" Name="Snow Brick Wall" />
-    <Item Id="596" Name="Blue Light" />
-    <Item Id="597" Name="Red Light" />
-    <Item Id="598" Name="Green Light" />
-    <Item Id="599" Name="Blue Present" />
-    <Item Id="600" Name="Green Present" />
-    <Item Id="601" Name="Yellow Present" />
-    <Item Id="602" Name="Snow Globe" />
-    <Item Id="603" Name="Carrot" />
-    <Item Id="604" Name="Adamantite Beam" />
-    <Item Id="605" Name="Adamantite Beam Wall" />
-    <Item Id="606" Name="Demonite Brick Wall" />
-    <Item Id="607" Name="Sandstone Brick" />
-    <Item Id="608" Name="Sandstone Brick Wall" />
-    <Item Id="609" Name="Ebonstone Brick" />
-    <Item Id="610" Name="Ebonstone Brick Wall" />
-    <Item Id="611" Name="Red Stucco" />
-    <Item Id="612" Name="Yellow Stucco" />
-    <Item Id="613" Name="Green Stucco" />
-    <Item Id="614" Name="Gray Stucco" />
-    <Item Id="615" Name="Red Stucco Wall" />
-    <Item Id="616" Name="Yellow Stucco Wall" />
-    <Item Id="617" Name="Green Stucco Wall" />
-    <Item Id="618" Name="Gray Stucco Wall" />
-    <Item Id="619" Name="Ebonwood" />
-    <Item Id="620" Name="Rich Mahogany" />
-    <Item Id="621" Name="Pearlwood" />
-    <Item Id="622" Name="Ebonwood Wall" />
-    <Item Id="623" Name="Rich Mahogany Wall" />
-    <Item Id="624" Name="Pearlwood Wall" />
-    <Item Id="625" Name="Ebonwood Chest" />
-    <Item Id="626" Name="Rich Mahogany Chest" />
-    <Item Id="627" Name="Pearlwood Chest" />
-    <Item Id="628" Name="Ebonwood Chair" />
-    <Item Id="629" Name="Rich Mahogany Chair" />
-    <Item Id="630" Name="Pearlwood Chair" />
-    <Item Id="631" Name="Ebonwood Platform" />
-    <Item Id="632" Name="Rich Mahogany Platform" />
-    <Item Id="633" Name="Pearlwood Platform" />
-    <Item Id="634" Name="Bone Platform" />
-    <Item Id="635" Name="Ebonwood Work Bench" />
-    <Item Id="636" Name="Rich Mahogany Work Bench" />
-    <Item Id="637" Name="Pearlwood Work Bench" />
-    <Item Id="638" Name="Ebonwood Table" />
-    <Item Id="639" Name="Rich Mahogany Table" />
-    <Item Id="640" Name="Pearlwood Table" />
-    <Item Id="641" Name="Ebonwood Piano" />
-    <Item Id="642" Name="Rich Mahogany Piano" />
-    <Item Id="643" Name="Pearlwood Piano" />
-    <Item Id="644" Name="Ebonwood Bed" />
-    <Item Id="645" Name="Rich Mahogany Bed" />
-    <Item Id="646" Name="Pearlwood Bed" />
-    <Item Id="647" Name="Ebonwood Dresser" />
-    <Item Id="648" Name="Rich Mahogany Dresser" />
-    <Item Id="649" Name="Pearlwood Dresser" />
-    <Item Id="650" Name="Ebonwood Door" />
-    <Item Id="651" Name="Rich Mahogany Door" />
-    <Item Id="652" Name="Pearlwood Door" />
-    <Item Id="653" Name="Ebonwood Sword" Rack="true" />
-    <Item Id="654" Name="Ebonwood Hammer" Scale="1.2" Rack="true" />
-    <Item Id="655" Name="Ebonwood Bow" Rack="true" />
-    <Item Id="656" Name="Rich Mahogany Sword" Rack="true" />
-    <Item Id="657" Name="Rich Mahogany Hammer" Scale="1.1" Rack="true" />
-    <Item Id="658" Name="Rich Mahogany Bow" Rack="true" />
-    <Item Id="659" Name="Pearlwood Sword" Rack="true" />
-    <Item Id="660" Name="Pearlwood Hammer" Scale="1.25" Rack="true" />
-    <Item Id="661" Name="Pearlwood Bow" Rack="true" />
-    <Item Id="662" Name="Rainbow Brick" />
-    <Item Id="663" Name="Rainbow Brick Wall" />
-    <Item Id="664" Name="Ice Block" />
-    <Item Id="665" Name="Red's Wings" />
-    <Item Id="666" Name="Red's Helmet" Head="45" />
-    <Item Id="667" Name="Red's Breastplate" Body="26" />
-    <Item Id="668" Name="Red's Leggings" Legs="25" />
-    <Item Id="669" Name="Fish" />
-    <Item Id="670" Name="Ice Boomerang" Rack="true" />
-    <Item Id="671" Name="Keybrand" Scale="1.2" Rack="true" />
-    <Item Id="672" Name="Cutlass" Scale="1.1" Rack="true" />
-    <Item Id="673" Name="Boreal Wood Work Bench" />
-    <Item Id="674" Name="True Excalibur" Scale="1.05" Rack="true" />
-    <Item Id="675" Name="True Night's Edge" Scale="1.15" Rack="true" />
-    <Item Id="676" Name="Frostbrand" Scale="1.15" Rack="true" />
-    <Item Id="677" Name="Boreal Wood Table" />
-    <Item Id="678" Name="Red Potion" />
-    <Item Id="679" Name="Tactical Shotgun" Rack="true" />
-    <Item Id="680" Name="Ivy Chest" />
-    <Item Id="681" Name="Ice Chest" />
-    <Item Id="682" Name="Marrow" Scale="1.1" Rack="true" />
-    <Item Id="683" Name="Unholy Trident" Rack="true" />
-    <Item Id="684" Name="Frost Helmet" Head="46" />
-    <Item Id="685" Name="Frost Breastplate" Body="27" />
-    <Item Id="686" Name="Frost Leggings" Legs="26" />
-    <Item Id="687" Name="Tin Helmet" Head="47" />
-    <Item Id="688" Name="Tin Chainmail" Body="28" />
-    <Item Id="689" Name="Tin Greaves" Legs="27" />
-    <Item Id="690" Name="Lead Helmet" Head="48" />
-    <Item Id="691" Name="Lead Chainmail" Body="29" />
-    <Item Id="692" Name="Lead Greaves" Legs="28" />
-    <Item Id="693" Name="Tungsten Helmet" Head="49" />
-    <Item Id="694" Name="Tungsten Chainmail" Body="30" />
-    <Item Id="695" Name="Tungsten Greaves" Legs="29" />
-    <Item Id="696" Name="Platinum Helmet" Head="50" />
-    <Item Id="697" Name="Platinum Chainmail" Body="31" />
-    <Item Id="698" Name="Platinum Greaves" Legs="30" />
-    <Item Id="699" Name="Tin Ore" />
-    <Item Id="700" Name="Lead Ore" />
-    <Item Id="701" Name="Tungsten Ore" />
-    <Item Id="702" Name="Platinum Ore" />
-    <Item Id="703" Name="Tin Bar" />
-    <Item Id="704" Name="Lead Bar" />
-    <Item Id="705" Name="Tungsten Bar" />
-    <Item Id="706" Name="Platinum Bar" />
-    <Item Id="707" Name="Tin Watch" />
-    <Item Id="708" Name="Tungsten Watch" />
-    <Item Id="709" Name="Platinum Watch" />
-    <Item Id="710" Name="Tin Chandelier" />
-    <Item Id="711" Name="Tungsten Chandelier" />
-    <Item Id="712" Name="Platinum Chandelier" />
-    <Item Id="713" Name="Platinum Candle" />
-    <Item Id="714" Name="Platinum Candelabra" />
-    <Item Id="715" Name="Platinum Crown" Head="51" />
-    <Item Id="716" Name="Lead Anvil" />
-    <Item Id="717" Name="Tin Brick" />
-    <Item Id="718" Name="Tungsten Brick" />
-    <Item Id="719" Name="Platinum Brick" />
-    <Item Id="720" Name="Tin Brick Wall" />
-    <Item Id="721" Name="Tungsten Brick Wall" />
-    <Item Id="722" Name="Platinum Brick Wall" />
-    <Item Id="723" Name="Beam Sword" Rack="true" />
-    <Item Id="724" Name="Ice Blade" Rack="true" />
-    <Item Id="725" Name="Ice Bow" Rack="true" />
-    <Item Id="726" Name="Frost Staff" Rack="true" />
-    <Item Id="727" Name="Wood Helmet" Head="52" />
-    <Item Id="728" Name="Wood Breastplate" Body="32" />
-    <Item Id="729" Name="Wood Greaves" Legs="31" />
-    <Item Id="730" Name="Ebonwood Helmet" Head="53" />
-    <Item Id="731" Name="Ebonwood Breastplate" Body="33" />
-    <Item Id="732" Name="Ebonwood Greaves" Legs="32" />
-    <Item Id="733" Name="Rich Mahogany Helmet" Head="54" />
-    <Item Id="734" Name="Rich Mahogany Breastplate" Body="34" />
-    <Item Id="735" Name="Rich Mahogany Greaves" Legs="33" />
-    <Item Id="736" Name="Pearlwood Helmet" Head="55" />
-    <Item Id="737" Name="Pearlwood Breastplate" Body="35" />
-    <Item Id="738" Name="Pearlwood Greaves" Legs="34" />
-    <Item Id="739" Name="Amethyst Staff" Rack="true" />
-    <Item Id="740" Name="Topaz Staff" Rack="true" />
-    <Item Id="741" Name="Sapphire Staff" Rack="true" />
-    <Item Id="742" Name="Emerald Staff" Rack="true" />
-    <Item Id="743" Name="Ruby Staff" Rack="true" />
-    <Item Id="744" Name="Diamond Staff" Rack="true" />
-    <Item Id="745" Name="Grass Wall" />
-    <Item Id="746" Name="Jungle Wall" />
-    <Item Id="747" Name="Flower Wall" />
-    <Item Id="748" Name="Jetpack" />
-    <Item Id="749" Name="Butterfly Wings" />
-    <Item Id="750" Name="Cactus Wall" />
-    <Item Id="751" Name="Cloud" />
-    <Item Id="752" Name="Cloud Wall" />
-    <Item Id="753" Name="Seaweed" />
-    <Item Id="754" Name="Rune Hat" Head="56" />
-    <Item Id="755" Name="Rune Robe" Body="36" />
-    <Item Id="756" Name="Mushroom Spear" Rack="true" />
-    <Item Id="757" Name="Terra Blade" Scale="1.1" Rack="true" />
-    <Item Id="758" Name="Grenade Launcher" Rack="true" />
-    <Item Id="759" Name="Rocket Launcher" Rack="true" />
-    <Item Id="760" Name="Proximity Mine Launcher" Rack="true" />
-    <Item Id="761" Name="Fairy Wings" />
-    <Item Id="762" Name="Slime Block" />
-    <Item Id="763" Name="Flesh Block" />
-    <Item Id="764" Name="Mushroom Wall" />
-    <Item Id="765" Name="Rain Cloud" />
-    <Item Id="766" Name="Bone Block" />
-    <Item Id="767" Name="Frozen Slime Block" />
-    <Item Id="768" Name="Bone Block Wall" />
-    <Item Id="769" Name="Slime Block Wall" />
-    <Item Id="770" Name="Flesh Block Wall" />
-    <Item Id="771" Name="Rocket I" Rack="true" />
-    <Item Id="772" Name="Rocket II" Rack="true" />
-    <Item Id="773" Name="Rocket III" Rack="true" />
-    <Item Id="774" Name="Rocket IV" Rack="true" />
-    <Item Id="775" Name="Asphalt Block" />
-    <Item Id="776" Name="Cobalt Pickaxe" Scale="1.15" Rack="true" />
-    <Item Id="777" Name="Mythril Pickaxe" Scale="1.15" Rack="true" />
-    <Item Id="778" Name="Adamantite Pickaxe" Scale="1.15" Rack="true" />
-    <Item Id="779" Name="Clentaminator" />
-    <Item Id="780" Name="Green Solution" />
-    <Item Id="781" Name="Blue Solution" />
-    <Item Id="782" Name="Purple Solution" />
-    <Item Id="783" Name="Dark Blue Solution" />
-    <Item Id="784" Name="Red Solution" />
-    <Item Id="785" Name="Harpy Wings" />
-    <Item Id="786" Name="Bone Wings" />
-    <Item Id="787" Name="Hammush" Scale="1.1" Rack="true" />
-    <Item Id="788" Name="Nettle Burst" Rack="true" />
-    <Item Id="789" Name="Ankh Banner" />
-    <Item Id="790" Name="Snake Banner" />
-    <Item Id="791" Name="Omega Banner" />
-    <Item Id="792" Name="Crimson Helmet" Head="57" />
-    <Item Id="793" Name="Crimson Scalemail" Body="37" />
-    <Item Id="794" Name="Crimson Greaves" Legs="35" />
-    <Item Id="795" Name="Blood Butcherer" Scale="1.1" Rack="true" />
-    <Item Id="796" Name="Tendon Bow" Rack="true" />
-    <Item Id="797" Name="Flesh Grinder" Scale="1.2" Rack="true" />
-    <Item Id="798" Name="Deathbringer Pickaxe" Scale="1.15" Rack="true" />
-    <Item Id="799" Name="Blood Lust Cluster" Scale="1.2" Rack="true" />
-    <Item Id="800" Name="The Undertaker" Scale="0.9" Rack="true" />
-    <Item Id="801" Name="The Meatball" Scale="1.1" Rack="true" />
-    <Item Id="802" Name="The Rotted Fork" Scale="1.1" Rack="true" />
-    <Item Id="803" Name="Eskimo Hood" Head="58" />
-    <Item Id="804" Name="Eskimo Coat" Body="38" />
-    <Item Id="805" Name="Eskimo Pants" Legs="36" />
-    <Item Id="806" Name="Living Wood Chair" />
-    <Item Id="807" Name="Cactus Chair" />
-    <Item Id="808" Name="Bone Chair" />
-    <Item Id="809" Name="Flesh Chair" />
-    <Item Id="810" Name="Mushroom Chair" />
-    <Item Id="811" Name="Bone Work Bench" />
-    <Item Id="812" Name="Cactus Work Bench" />
-    <Item Id="813" Name="Flesh Work Bench" />
-    <Item Id="814" Name="Mushroom Work Bench" />
-    <Item Id="815" Name="Slime Work Bench" />
-    <Item Id="816" Name="Cactus Door" />
-    <Item Id="817" Name="Flesh Door" />
-    <Item Id="818" Name="Mushroom Door" />
-    <Item Id="819" Name="Living Wood Door" />
-    <Item Id="820" Name="Bone Door" />
-    <Item Id="821" Name="Flame Wings" />
-    <Item Id="822" Name="Frozen Wings" />
-    <Item Id="823" Name="Spectre Wings" />
-    <Item Id="824" Name="Sunplate Block" />
-    <Item Id="825" Name="Disc Wall" />
-    <Item Id="826" Name="Skyware Chair" />
-    <Item Id="827" Name="Bone Table" />
-    <Item Id="828" Name="Flesh Table" />
-    <Item Id="829" Name="Living Wood Table" />
-    <Item Id="830" Name="Skyware Table" />
-    <Item Id="831" Name="Living Wood Chest" />
-    <Item Id="832" Name="Living Wood Wand" />
-    <Item Id="833" Name="Purple Ice Block" />
-    <Item Id="834" Name="Pink Ice Block" />
-    <Item Id="835" Name="Red Ice Block" />
-    <Item Id="836" Name="Crimstone Block" />
-    <Item Id="837" Name="Skyware Door" />
-    <Item Id="838" Name="Skyware Chest" />
-    <Item Id="839" Name="Steampunk Hat" Head="59" />
-    <Item Id="840" Name="Steampunk Shirt" Body="39" />
-    <Item Id="841" Name="Steampunk Pants" Legs="37" />
-    <Item Id="842" Name="Bee Hat" Head="60" />
-    <Item Id="843" Name="Bee Shirt" Body="40" />
-    <Item Id="844" Name="Bee Pants" Legs="38" />
-    <Item Id="845" Name="World Banner" />
-    <Item Id="846" Name="Sun Banner" />
-    <Item Id="847" Name="Gravity Banner" />
-    <Item Id="848" Name="Pharaoh's Mask" Head="61" />
-    <Item Id="849" Name="Actuator" />
-    <Item Id="850" Name="Blue Wrench" />
-    <Item Id="851" Name="Green Wrench" />
-    <Item Id="852" Name="Blue Pressure Plate" />
-    <Item Id="853" Name="Yellow Pressure Plate" />
-    <Item Id="854" Name="Discount Card" />
-    <Item Id="855" Name="Lucky Coin" />
-    <Item Id="856" Name="Unicorn on a Stick" />
-    <Item Id="857" Name="Sandstorm in a Bottle" />
-    <Item Id="858" Name="Boreal Wood Sofa" />
-    <Item Id="859" Name="Beach Ball" />
-    <Item Id="860" Name="Charm of Myths" />
-    <Item Id="861" Name="Moon Shell" />
-    <Item Id="862" Name="Star Veil" />
-    <Item Id="863" Name="Water Walking Boots" />
-    <Item Id="864" Name="Tiara" Head="62" />
-    <Item Id="865" Name="Princess Dress" Body="41" />
-    <Item Id="866" Name="Pharaoh's Robe" Body="42" />
-    <Item Id="867" Name="Green Cap" Head="63" />
-    <Item Id="868" Name="Mushroom Cap" Head="64" />
-    <Item Id="869" Name="Tam O' Shanter" Head="65" />
-    <Item Id="870" Name="Mummy Mask" Head="66" />
-    <Item Id="871" Name="Mummy Shirt" Body="43" />
-    <Item Id="872" Name="Mummy Pants" Legs="39" />
-    <Item Id="873" Name="Cowboy Hat" Head="67" />
-    <Item Id="874" Name="Cowboy Jacket" Body="44" />
-    <Item Id="875" Name="Cowboy Pants" Legs="40" />
-    <Item Id="876" Name="Pirate Hat" Head="68" />
-    <Item Id="877" Name="Pirate Shirt" Body="45" />
-    <Item Id="878" Name="Pirate Pants" Legs="41" />
-    <Item Id="879" Name="Viking Helmet" Head="69" />
-    <Item Id="880" Name="Crimtane Ore" />
-    <Item Id="881" Name="Cactus Sword" Rack="true" />
-    <Item Id="882" Name="Cactus Pickaxe" Rack="true" />
-    <Item Id="883" Name="Ice Brick" />
-    <Item Id="884" Name="Ice Brick Wall" />
-    <Item Id="885" Name="Adhesive Bandage" />
-    <Item Id="886" Name="Armor Polish" />
-    <Item Id="887" Name="Bezoar" />
-    <Item Id="888" Name="Blindfold" />
-    <Item Id="889" Name="Fast Clock" />
-    <Item Id="890" Name="Megaphone" />
-    <Item Id="891" Name="Nazar" />
-    <Item Id="892" Name="Vitamins" />
-    <Item Id="893" Name="Trifold Map" />
-    <Item Id="894" Name="Cactus Helmet" Head="70" />
-    <Item Id="895" Name="Cactus Breastplate" Body="46" />
-    <Item Id="896" Name="Cactus Leggings" Legs="42" />
-    <Item Id="897" Name="Power Glove" />
-    <Item Id="898" Name="Lightning Boots" />
-    <Item Id="899" Name="Sun Stone" />
-    <Item Id="900" Name="Moon Stone" />
-    <Item Id="901" Name="Armor Bracing" />
-    <Item Id="902" Name="Medicated Bandage" />
-    <Item Id="903" Name="The Plan" />
-    <Item Id="904" Name="Countercurse Mantra" />
-    <Item Id="905" Name="Coin Gun" Rack="true" />
-    <Item Id="906" Name="Lava Charm" />
-    <Item Id="907" Name="Obsidian Water Walking Boots" />
-    <Item Id="908" Name="Lava Waders" />
-    <Item Id="909" Name="Pure Water Fountain" />
-    <Item Id="910" Name="Desert Water Fountain" />
-    <Item Id="911" Name="Shadewood" />
-    <Item Id="912" Name="Shadewood Door" />
-    <Item Id="913" Name="Shadewood Platform" />
-    <Item Id="914" Name="Shadewood Chest" />
-    <Item Id="915" Name="Shadewood Chair" />
-    <Item Id="916" Name="Shadewood Work Bench" />
-    <Item Id="917" Name="Shadewood Table" />
-    <Item Id="918" Name="Shadewood Dresser" />
-    <Item Id="919" Name="Shadewood Piano" />
-    <Item Id="920" Name="Shadewood Bed" />
-    <Item Id="921" Name="Shadewood Sword" Rack="true" />
-    <Item Id="922" Name="Shadewood Hammer" Scale="1.2" Rack="true" />
-    <Item Id="923" Name="Shadewood Bow" Rack="true" />
-    <Item Id="924" Name="Shadewood Helmet" Head="71" />
-    <Item Id="925" Name="Shadewood Breastplate" Body="47" />
-    <Item Id="926" Name="Shadewood Greaves" Legs="43" />
-    <Item Id="927" Name="Shadewood Wall" />
-    <Item Id="928" Name="Cannon" />
-    <Item Id="929" Name="Cannonball" Rack="true" />
-    <Item Id="930" Name="Flare Gun" Scale="0.9" Rack="true" />
-    <Item Id="931" Name="Flare" Rack="true" />
-    <Item Id="932" Name="Bone Wand" />
-    <Item Id="933" Name="Leaf Wand" />
-    <Item Id="934" Name="Flying Carpet" />
-    <Item Id="935" Name="Avenger Emblem" />
-    <Item Id="936" Name="Mechanical Glove" />
-    <Item Id="937" Name="Land Mine" />
-    <Item Id="938" Name="Paladin's Shield" />
-    <Item Id="939" Name="Web Slinger" />
-    <Item Id="940" Name="Jungle Water Fountain" />
-    <Item Id="941" Name="Icy Water Fountain" />
-    <Item Id="942" Name="Corrupt Water Fountain" />
-    <Item Id="943" Name="Crimson Water Fountain" />
-    <Item Id="944" Name="Hallowed Water Fountain" />
-    <Item Id="945" Name="Blood Water Fountain" />
-    <Item Id="946" Name="Umbrella" />
-    <Item Id="947" Name="Chlorophyte Ore" />
-    <Item Id="948" Name="Steampunk Wings" />
-    <Item Id="949" Name="Snowball" Rack="true" />
-    <Item Id="950" Name="Ice Skates" />
-    <Item Id="951" Name="Snowball Launcher" />
-    <Item Id="952" Name="Web Covered Chest" />
-    <Item Id="953" Name="Climbing Claws" />
-    <Item Id="954" Name="Ancient Iron Helmet" Head="72" />
-    <Item Id="955" Name="Ancient Gold Helmet" Head="73" />
-    <Item Id="956" Name="Ancient Shadow Helmet" Head="74" />
-    <Item Id="957" Name="Ancient Shadow Scalemail" Body="48" />
-    <Item Id="958" Name="Ancient Shadow Greaves" Legs="44" />
-    <Item Id="959" Name="Ancient Necro Helmet" Head="75" />
-    <Item Id="960" Name="Ancient Cobalt Helmet" Head="76" />
-    <Item Id="961" Name="Ancient Cobalt Breastplate" Body="49" />
-    <Item Id="962" Name="Ancient Cobalt Leggings" Legs="45" />
-    <Item Id="963" Name="Black Belt" />
-    <Item Id="964" Name="Boomstick" Rack="true" />
-    <Item Id="965" Name="Rope" />
-    <Item Id="966" Name="Campfire" />
-    <Item Id="967" Name="Marshmallow" />
-    <Item Id="968" Name="Marshmallow on a Stick" />
-    <Item Id="969" Name="Cooked Marshmallow" />
-    <Item Id="970" Name="Red Rocket" />
-    <Item Id="971" Name="Green Rocket" />
-    <Item Id="972" Name="Blue Rocket" />
-    <Item Id="973" Name="Yellow Rocket" />
-    <Item Id="974" Name="Ice Torch" />
-    <Item Id="975" Name="Shoe Spikes" />
-    <Item Id="976" Name="Tiger Climbing Gear" />
-    <Item Id="977" Name="Tabi" />
-    <Item Id="978" Name="Pink Eskimo Hood" Head="77" />
-    <Item Id="979" Name="Pink Eskimo Coat" Body="50" />
-    <Item Id="980" Name="Pink Eskimo Pants" Legs="46" />
-    <Item Id="981" Name="Pink Thread" />
-    <Item Id="982" Name="Mana Regeneration Band" />
-    <Item Id="983" Name="Sandstorm in a Balloon" />
-    <Item Id="984" Name="Master Ninja Gear" />
-    <Item Id="985" Name="Rope Coil" />
-    <Item Id="986" Name="Blowgun" Rack="true" />
-    <Item Id="987" Name="Blizzard in a Bottle" />
-    <Item Id="988" Name="Frostburn Arrow" Rack="true" />
-    <Item Id="989" Name="Enchanted Sword" Scale="1.1" Rack="true" />
-    <Item Id="990" Name="Pickaxe Axe" Scale="1.1" Rack="true" />
-    <Item Id="991" Name="Cobalt Waraxe" Scale="1.1" Rack="true" />
-    <Item Id="992" Name="Mythril Waraxe" Scale="1.1" Rack="true" />
-    <Item Id="993" Name="Adamantite Waraxe" Scale="1.1" Rack="true" />
-    <Item Id="994" Name="Eater's Bone" />
-    <Item Id="995" Name="Blend-O-Matic" />
-    <Item Id="996" Name="Meat Grinder" />
-    <Item Id="997" Name="Extractinator" />
-    <Item Id="998" Name="Solidifier" />
-    <Item Id="999" Name="Amber" />
-    <Item Id="1000" Name="Confetti Gun" />
-    <Item Id="1001" Name="Chlorophyte Mask" Head="78" />
-    <Item Id="1002" Name="Chlorophyte Helmet" Head="79" />
-    <Item Id="1003" Name="Chlorophyte Headgear" Head="80" />
-    <Item Id="1004" Name="Chlorophyte Plate Mail" Body="51" />
-    <Item Id="1005" Name="Chlorophyte Greaves" Legs="47" />
-    <Item Id="1006" Name="Chlorophyte Bar" />
-    <Item Id="1007" Name="Red Dye" />
-    <Item Id="1008" Name="Orange Dye" />
-    <Item Id="1009" Name="Yellow Dye" />
-    <Item Id="1010" Name="Lime Dye" />
-    <Item Id="1011" Name="Green Dye" />
-    <Item Id="1012" Name="Teal Dye" />
-    <Item Id="1013" Name="Cyan Dye" />
-    <Item Id="1014" Name="Sky Blue Dye" />
-    <Item Id="1015" Name="Blue Dye" />
-    <Item Id="1016" Name="Purple Dye" />
-    <Item Id="1017" Name="Violet Dye" />
-    <Item Id="1018" Name="Pink Dye" />
-    <Item Id="1019" Name="Red and Black Dye" />
-    <Item Id="1020" Name="Orange and Black Dye" />
-    <Item Id="1021" Name="Yellow and Black Dye" />
-    <Item Id="1022" Name="Lime and Black Dye" />
-    <Item Id="1023" Name="Green and Black Dye" />
-    <Item Id="1024" Name="Teal and Black Dye" />
-    <Item Id="1025" Name="Cyan and Black Dye" />
-    <Item Id="1026" Name="Sky Blue and Black Dye" />
-    <Item Id="1027" Name="Blue and Black Dye" />
-    <Item Id="1028" Name="Purple and Black Dye" />
-    <Item Id="1029" Name="Violet and Black Dye" />
-    <Item Id="1030" Name="Pink and Black Dye" />
-    <Item Id="1031" Name="Flame Dye" />
-    <Item Id="1032" Name="Flame and Black Dye" />
-    <Item Id="1033" Name="Green Flame Dye" />
-    <Item Id="1034" Name="Green Flame and Black Dye" />
-    <Item Id="1035" Name="Blue Flame Dye" />
-    <Item Id="1036" Name="Blue Flame and Black Dye" />
-    <Item Id="1037" Name="Silver Dye" />
-    <Item Id="1038" Name="Bright Red Dye" />
-    <Item Id="1039" Name="Bright Orange Dye" />
-    <Item Id="1040" Name="Bright Yellow Dye" />
-    <Item Id="1041" Name="Bright Lime Dye" />
-    <Item Id="1042" Name="Bright Green Dye" />
-    <Item Id="1043" Name="Bright Teal Dye" />
-    <Item Id="1044" Name="Bright Cyan Dye" />
-    <Item Id="1045" Name="Bright Sky Blue Dye" />
-    <Item Id="1046" Name="Bright Blue Dye" />
-    <Item Id="1047" Name="Bright Purple Dye" />
-    <Item Id="1048" Name="Bright Violet Dye" />
-    <Item Id="1049" Name="Bright Pink Dye" />
-    <Item Id="1050" Name="Black Dye" />
-    <Item Id="1051" Name="Red and Silver Dye" />
-    <Item Id="1052" Name="Orange and Silver Dye" />
-    <Item Id="1053" Name="Yellow and Silver Dye" />
-    <Item Id="1054" Name="Lime and Silver Dye" />
-    <Item Id="1055" Name="Green and Silver Dye" />
-    <Item Id="1056" Name="Teal and Silver Dye" />
-    <Item Id="1057" Name="Cyan and Silver Dye" />
-    <Item Id="1058" Name="Sky Blue and Silver Dye" />
-    <Item Id="1059" Name="Blue and Silver Dye" />
-    <Item Id="1060" Name="Purple and Silver Dye" />
-    <Item Id="1061" Name="Violet and Silver Dye" />
-    <Item Id="1062" Name="Pink and Silver Dye" />
-    <Item Id="1063" Name="Intense Flame Dye" />
-    <Item Id="1064" Name="Intense Green Flame Dye" />
-    <Item Id="1065" Name="Intense Blue Flame Dye" />
-    <Item Id="1066" Name="Rainbow Dye" />
-    <Item Id="1067" Name="Intense Rainbow Dye" />
-    <Item Id="1068" Name="Yellow Gradient Dye" />
-    <Item Id="1069" Name="Cyan Gradient Dye" />
-    <Item Id="1070" Name="Violet Gradient Dye" />
-    <Item Id="1071" Name="Paintbrush" />
-    <Item Id="1072" Name="Paint Roller" />
-    <Item Id="1073" Name="Red Paint" />
-    <Item Id="1074" Name="Orange Paint" />
-    <Item Id="1075" Name="Yellow Paint" />
-    <Item Id="1076" Name="Lime Paint" />
-    <Item Id="1077" Name="Green Paint" />
-    <Item Id="1078" Name="Teal Paint" />
-    <Item Id="1079" Name="Cyan Paint" />
-    <Item Id="1080" Name="Sky Blue Paint" />
-    <Item Id="1081" Name="Blue Paint" />
-    <Item Id="1082" Name="Purple Paint" />
-    <Item Id="1083" Name="Violet Paint" />
-    <Item Id="1084" Name="Pink Paint" />
-    <Item Id="1085" Name="Deep Red Paint" />
-    <Item Id="1086" Name="Deep Orange Paint" />
-    <Item Id="1087" Name="Deep Yellow Paint" />
-    <Item Id="1088" Name="Deep Lime Paint" />
-    <Item Id="1089" Name="Deep Green Paint" />
-    <Item Id="1090" Name="Deep Teal Paint" />
-    <Item Id="1091" Name="Deep Cyan Paint" />
-    <Item Id="1092" Name="Deep Sky Blue Paint" />
-    <Item Id="1093" Name="Deep Blue Paint" />
-    <Item Id="1094" Name="Deep Purple Paint" />
-    <Item Id="1095" Name="Deep Violet Paint" />
-    <Item Id="1096" Name="Deep Pink Paint" />
-    <Item Id="1097" Name="Black Paint" />
-    <Item Id="1098" Name="White Paint" />
-    <Item Id="1099" Name="Gray Paint" />
-    <Item Id="1100" Name="Paint Scraper" />
-    <Item Id="1101" Name="Lihzahrd Brick" />
-    <Item Id="1102" Name="Lihzahrd Brick Wall" />
-    <Item Id="1103" Name="Slush Block" />
-    <Item Id="1104" Name="Palladium Ore" />
-    <Item Id="1105" Name="Orichalcum Ore" />
-    <Item Id="1106" Name="Titanium Ore" />
-    <Item Id="1107" Name="Teal Mushroom" />
-    <Item Id="1108" Name="Green Mushroom" />
-    <Item Id="1109" Name="Sky Blue Flower" />
-    <Item Id="1110" Name="Yellow Marigold" />
-    <Item Id="1111" Name="Blue Berries" />
-    <Item Id="1112" Name="Lime Kelp" />
-    <Item Id="1113" Name="Pink Prickly Pear" />
-    <Item Id="1114" Name="Orange Bloodroot" />
-    <Item Id="1115" Name="Red Husk" />
-    <Item Id="1116" Name="Cyan Husk" />
-    <Item Id="1117" Name="Violet Husk" />
-    <Item Id="1118" Name="Purple Mucos" />
-    <Item Id="1119" Name="Black Ink" />
-    <Item Id="1120" Name="Dye Vat" />
-    <Item Id="1121" Name="Bee Gun" Scale="0.8" Rack="true" />
-    <Item Id="1122" Name="Possessed Hatchet" Rack="true" />
-    <Item Id="1123" Name="Bee Keeper" Scale="1.1" Rack="true" />
-    <Item Id="1124" Name="Hive" />
-    <Item Id="1125" Name="Honey Block" />
-    <Item Id="1126" Name="Hive Wall" />
-    <Item Id="1127" Name="Crispy Honey Block" />
-    <Item Id="1128" Name="Honey Bucket" />
-    <Item Id="1129" Name="Hive Wand" />
-    <Item Id="1130" Name="Beenade" Rack="true" />
-    <Item Id="1131" Name="Gravity Globe" />
-    <Item Id="1132" Name="Honey Comb" />
-    <Item Id="1133" Name="Abeemination" />
-    <Item Id="1134" Name="Bottled Honey" />
-    <Item Id="1135" Name="Rain Hat" Head="81" />
-    <Item Id="1136" Name="Rain Coat" Body="52" />
-    <Item Id="1137" Name="Lihzahrd Door" />
-    <Item Id="1138" Name="Dungeon Door" />
-    <Item Id="1139" Name="Lead Door" />
-    <Item Id="1140" Name="Iron Door" />
-    <Item Id="1141" Name="Temple Key" />
-    <Item Id="1142" Name="Lihzahrd Chest" />
-    <Item Id="1143" Name="Lihzahrd Chair" />
-    <Item Id="1144" Name="Lihzahrd Table" />
-    <Item Id="1145" Name="Lihzahrd Work Bench" />
-    <Item Id="1146" Name="Super Dart Trap" />
-    <Item Id="1147" Name="Flame Trap" />
-    <Item Id="1148" Name="Spiky Ball Trap" />
-    <Item Id="1149" Name="Spear Trap" />
-    <Item Id="1150" Name="Wooden Spike" />
-    <Item Id="1151" Name="Lihzahrd Pressure Plate" />
-    <Item Id="1152" Name="Lihzahrd Statue" />
-    <Item Id="1153" Name="Lihzahrd Watcher Statue" />
-    <Item Id="1154" Name="Lihzahrd Guardian Statue" />
-    <Item Id="1155" Name="Wasp Gun" Rack="true" />
-    <Item Id="1156" Name="Piranha Gun" Scale="1.1" Rack="true" />
-    <Item Id="1157" Name="Pygmy Staff" Rack="true" />
-    <Item Id="1158" Name="Pygmy Necklace" />
-    <Item Id="1159" Name="Tiki Mask" Head="82" />
-    <Item Id="1160" Name="Tiki Shirt" Body="53" />
-    <Item Id="1161" Name="Tiki Pants" Legs="48" />
-    <Item Id="1162" Name="Leaf Wings" />
-    <Item Id="1163" Name="Blizzard in a Balloon" />
-    <Item Id="1164" Name="Bundle of Balloons" />
-    <Item Id="1165" Name="Bat Wings" />
-    <Item Id="1166" Name="Bone Sword" Scale="1.05" Rack="true" />
-    <Item Id="1167" Name="Hercules Beetle" />
-    <Item Id="1168" Name="Smoke Bomb" />
-    <Item Id="1169" Name="Bone Key" />
-    <Item Id="1170" Name="Nectar" />
-    <Item Id="1171" Name="Tiki Totem" />
-    <Item Id="1172" Name="Lizard Egg" />
-    <Item Id="1173" Name="Grave Marker" />
-    <Item Id="1174" Name="Cross Grave Marker" />
-    <Item Id="1175" Name="Headstone" />
-    <Item Id="1176" Name="Gravestone" />
-    <Item Id="1177" Name="Obelisk" />
-    <Item Id="1178" Name="Leaf Blower" Rack="true" />
-    <Item Id="1179" Name="Chlorophyte Bullet" Rack="true" />
-    <Item Id="1180" Name="Parrot Cracker" />
-    <Item Id="1181" Name="Strange Glowing Mushroom" />
-    <Item Id="1182" Name="Seedling" />
-    <Item Id="1183" Name="Wisp in a Bottle" />
-    <Item Id="1184" Name="Palladium Bar" />
-    <Item Id="1185" Name="Palladium Sword" Scale="1.125" Rack="true" />
-    <Item Id="1186" Name="Palladium Pike" Scale="1.1" Rack="true" />
-    <Item Id="1187" Name="Palladium Repeater" Rack="true" />
-    <Item Id="1188" Name="Palladium Pickaxe" Scale="1.15" Rack="true" />
-    <Item Id="1189" Name="Palladium Drill" Rack="true" />
-    <Item Id="1190" Name="Palladium Chainsaw" Rack="true" />
-    <Item Id="1191" Name="Orichalcum Bar" />
-    <Item Id="1192" Name="Orichalcum Sword" Scale="1.17" Rack="true" />
-    <Item Id="1193" Name="Orichalcum Halberd" Scale="1.1" Rack="true" />
-    <Item Id="1194" Name="Orichalcum Repeater" Rack="true" />
-    <Item Id="1195" Name="Orichalcum Pickaxe" Scale="1.15" Rack="true" />
-    <Item Id="1196" Name="Orichalcum Drill" Rack="true" />
-    <Item Id="1197" Name="Orichalcum Chainsaw" Rack="true" />
-    <Item Id="1198" Name="Titanium Bar" />
-    <Item Id="1199" Name="Titanium Sword" Scale="1.2" Rack="true" />
-    <Item Id="1200" Name="Titanium Trident" Scale="1.1" Rack="true" />
-    <Item Id="1201" Name="Titanium Repeater" Rack="true" />
-    <Item Id="1202" Name="Titanium Pickaxe" Scale="1.15" Rack="true" />
-    <Item Id="1203" Name="Titanium Drill" Rack="true" />
-    <Item Id="1204" Name="Titanium Chainsaw" Rack="true" />
-    <Item Id="1205" Name="Palladium Mask" Head="83" />
-    <Item Id="1206" Name="Palladium Helmet" Head="84" />
-    <Item Id="1207" Name="Palladium Headgear" Head="85" />
-    <Item Id="1208" Name="Palladium Breastplate" Body="54" />
-    <Item Id="1209" Name="Palladium Leggings" Legs="49" />
-    <Item Id="1210" Name="Orichalcum Mask" Head="86" />
-    <Item Id="1211" Name="Orichalcum Helmet" Head="87" />
-    <Item Id="1212" Name="Orichalcum Headgear" Head="88" />
-    <Item Id="1213" Name="Orichalcum Breastplate" Body="55" />
-    <Item Id="1214" Name="Orichalcum Leggings" Legs="50" />
-    <Item Id="1215" Name="Titanium Mask" Head="89" />
-    <Item Id="1216" Name="Titanium Helmet" Head="90" />
-    <Item Id="1217" Name="Titanium Headgear" Head="91" />
-    <Item Id="1218" Name="Titanium Breastplate" Body="56" />
-    <Item Id="1219" Name="Titanium Leggings" Legs="51" />
-    <Item Id="1220" Name="Orichalcum Anvil" />
-    <Item Id="1221" Name="Titanium Forge" />
-    <Item Id="1222" Name="Palladium Waraxe" Scale="1.1" Rack="true" />
-    <Item Id="1223" Name="Orichalcum Waraxe" Scale="1.1" Rack="true" />
-    <Item Id="1224" Name="Titanium Waraxe" Scale="1.1" Rack="true" />
-    <Item Id="1225" Name="Hallowed Bar" />
-    <Item Id="1226" Name="Chlorophyte Claymore" Scale="1.25" Rack="true" />
-    <Item Id="1227" Name="Chlorophyte Saber" Rack="true" />
-    <Item Id="1228" Name="Chlorophyte Partisan" Scale="1.1" Rack="true" />
-    <Item Id="1229" Name="Chlorophyte Shotbow" Rack="true" />
-    <Item Id="1230" Name="Chlorophyte Pickaxe" Scale="1.15" Rack="true" />
-    <Item Id="1231" Name="Chlorophyte Drill" Rack="true" />
-    <Item Id="1232" Name="Chlorophyte Chainsaw" Rack="true" />
-    <Item Id="1233" Name="Chlorophyte Greataxe" Scale="1.15" Rack="true" />
-    <Item Id="1234" Name="Chlorophyte Warhammer" Scale="1.25" Rack="true" />
-    <Item Id="1235" Name="Chlorophyte Arrow" Rack="true" />
-    <Item Id="1236" Name="Amethyst Hook" />
-    <Item Id="1237" Name="Topaz Hook" />
-    <Item Id="1238" Name="Sapphire Hook" />
-    <Item Id="1239" Name="Emerald Hook" />
-    <Item Id="1240" Name="Ruby Hook" />
-    <Item Id="1241" Name="Diamond Hook" />
-    <Item Id="1242" Name="Amber Mosquito" />
-    <Item Id="1243" Name="Umbrella Hat" Head="92" />
-    <Item Id="1244" Name="Nimbus Rod" Rack="true" />
-    <Item Id="1245" Name="Orange Torch" />
-    <Item Id="1246" Name="Crimsand Block" />
-    <Item Id="1247" Name="Bee Cloak" />
-    <Item Id="1248" Name="Eye of the Golem" />
-    <Item Id="1249" Name="Honey Balloon" />
-    <Item Id="1250" Name="Blue Horseshoe Balloon" />
-    <Item Id="1251" Name="White Horseshoe Balloon" />
-    <Item Id="1252" Name="Yellow Horseshoe Balloon" />
-    <Item Id="1253" Name="Frozen Turtle Shell" />
-    <Item Id="1254" Name="Sniper Rifle" Rack="true" />
-    <Item Id="1255" Name="Venus Magnum" Scale="0.85" Rack="true" />
-    <Item Id="1256" Name="Crimson Rod" Rack="true" />
-    <Item Id="1257" Name="Crimtane Bar" />
-    <Item Id="1258" Name="Stynger" Rack="true" />
-    <Item Id="1259" Name="Flower Pow" Scale="1.1" Rack="true" />
-    <Item Id="1260" Name="Rainbow Gun" Rack="true" />
-    <Item Id="1261" Name="Stynger Bolt" Rack="true" />
-    <Item Id="1262" Name="Chlorophyte Jackhammer" Rack="true" />
-    <Item Id="1263" Name="Teleporter" />
-    <Item Id="1264" Name="Flower of Frost" Rack="true" />
-    <Item Id="1265" Name="Uzi" Scale="0.75" Rack="true" />
-    <Item Id="1266" Name="Magnet Sphere" Rack="true" />
-    <Item Id="1267" Name="Purple Stained Glass" />
-    <Item Id="1268" Name="Yellow Stained Glass" />
-    <Item Id="1269" Name="Blue Stained Glass" />
-    <Item Id="1270" Name="Green Stained Glass" />
-    <Item Id="1271" Name="Red Stained Glass" />
-    <Item Id="1272" Name="Multicolored Stained Glass" />
-    <Item Id="1273" Name="Skeletron Hand" />
-    <Item Id="1274" Name="Skull" Head="93" />
-    <Item Id="1275" Name="Balla Hat" Head="94" />
-    <Item Id="1276" Name="Gangsta Hat" Head="95" />
-    <Item Id="1277" Name="Sailor Hat" Head="96" />
-    <Item Id="1278" Name="Eye Patch" Head="97" />
-    <Item Id="1279" Name="Sailor Shirt" Body="57" />
-    <Item Id="1280" Name="Sailor Pants" Legs="52" />
-    <Item Id="1281" Name="Skeletron Mask" Head="98" />
-    <Item Id="1282" Name="Amethyst Robe" Body="58" />
-    <Item Id="1283" Name="Topaz Robe" Body="59" />
-    <Item Id="1284" Name="Sapphire Robe" Body="60" />
-    <Item Id="1285" Name="Emerald Robe" Body="61" />
-    <Item Id="1286" Name="Ruby Robe" Body="62" />
-    <Item Id="1287" Name="Diamond Robe" Body="63" />
-    <Item Id="1288" Name="White Tuxedo Shirt" Body="64" />
-    <Item Id="1289" Name="White Tuxedo Pants" Legs="53" />
-    <Item Id="1290" Name="Panic Necklace" />
-    <Item Id="1291" Name="Life Fruit" />
-    <Item Id="1292" Name="Lihzahrd Altar" />
-    <Item Id="1293" Name="Lihzahrd Power Cell" />
-    <Item Id="1294" Name="Picksaw" Scale="1.15" Rack="true" />
-    <Item Id="1295" Name="Heat Ray" Rack="true" />
-    <Item Id="1296" Name="Staff of Earth" Rack="true" />
-    <Item Id="1297" Name="Golem Fist" Scale="0.9" Rack="true" />
-    <Item Id="1298" Name="Water Chest" />
-    <Item Id="1299" Name="Binoculars" />
-    <Item Id="1300" Name="Rifle Scope" />
-    <Item Id="1301" Name="Destroyer Emblem" />
-    <Item Id="1302" Name="High Velocity Bullet" Rack="true" />
-    <Item Id="1303" Name="Jellyfish Necklace" />
-    <Item Id="1304" Name="Zombie Arm" Rack="true" />
-    <Item Id="1305" Name="The Axe" Scale="1.15" Rack="true" />
-    <Item Id="1306" Name="Ice Sickle" Scale="1.15" Rack="true" />
-    <Item Id="1307" Name="Clothier Voodoo Doll" />
-    <Item Id="1308" Name="Poison Staff" Rack="true" />
-    <Item Id="1309" Name="Slime Staff" />
-    <Item Id="1310" Name="Poison Dart" Rack="true" />
-    <Item Id="1311" Name="Eye Spring" />
-    <Item Id="1312" Name="Toy Sled" />
-    <Item Id="1313" Name="Book of Skulls" Scale="0.9" Rack="true" />
-    <Item Id="1314" Name="KO Cannon" Scale="0.9" Rack="true" />
-    <Item Id="1315" Name="Pirate Map" />
-    <Item Id="1316" Name="Turtle Helmet" Head="99" />
-    <Item Id="1317" Name="Turtle Scale Mail" Body="65" />
-    <Item Id="1318" Name="Turtle Leggings" Legs="54" />
-    <Item Id="1319" Name="Snowball Cannon" Rack="true" />
-    <Item Id="1320" Name="Bone Pickaxe" Scale="1.15" Rack="true" />
-    <Item Id="1321" Name="Magic Quiver" />
-    <Item Id="1322" Name="Magma Stone" />
-    <Item Id="1323" Name="Obsidian Rose" />
-    <Item Id="1324" Name="Bananarang" Rack="true" />
-    <Item Id="1325" Name="Chain Knife" Rack="true" />
-    <Item Id="1326" Name="Rod of Discord" Rack="true" />
-    <Item Id="1327" Name="Death Sickle" Scale="1.15" Rack="true" />
-    <Item Id="1328" Name="Turtle Shell" />
-    <Item Id="1329" Name="Tissue Sample" />
-    <Item Id="1330" Name="Vertebrae" />
-    <Item Id="1331" Name="Bloody Spine" />
-    <Item Id="1332" Name="Ichor" />
-    <Item Id="1333" Name="Ichor Torch" />
-    <Item Id="1334" Name="Ichor Arrow" Rack="true" />
-    <Item Id="1335" Name="Ichor Bullet" Rack="true" />
-    <Item Id="1336" Name="Golden Shower" Rack="true" />
-    <Item Id="1337" Name="Bunny Cannon" />
-    <Item Id="1338" Name="Explosive Bunny" Rack="true" />
-    <Item Id="1339" Name="Vial of Venom" />
-    <Item Id="1340" Name="Flask of Venom" />
-    <Item Id="1341" Name="Venom Arrow" Rack="true" />
-    <Item Id="1342" Name="Venom Bullet" Rack="true" />
-    <Item Id="1343" Name="Fire Gauntlet" />
-    <Item Id="1344" Name="Cog" />
-    <Item Id="1345" Name="Confetti" />
-    <Item Id="1346" Name="Nanites" />
-    <Item Id="1347" Name="Explosive Powder" />
-    <Item Id="1348" Name="Gold Dust" />
-    <Item Id="1349" Name="Party Bullet" Rack="true" />
-    <Item Id="1350" Name="Nano Bullet" Rack="true" />
-    <Item Id="1351" Name="Exploding Bullet" Rack="true" />
-    <Item Id="1352" Name="Golden Bullet" Rack="true" />
-    <Item Id="1353" Name="Flask of Cursed Flames" />
-    <Item Id="1354" Name="Flask of Fire" />
-    <Item Id="1355" Name="Flask of Gold" />
-    <Item Id="1356" Name="Flask of Ichor" />
-    <Item Id="1357" Name="Flask of Nanites" />
-    <Item Id="1358" Name="Flask of Party" />
-    <Item Id="1359" Name="Flask of Poison" />
-    <Item Id="1360" Name="Eye of Cthulhu Trophy" />
-    <Item Id="1361" Name="Eater of Worlds Trophy" />
-    <Item Id="1362" Name="Brain of Cthulhu Trophy" />
-    <Item Id="1363" Name="Skeletron Trophy" />
-    <Item Id="1364" Name="Queen Bee Trophy" />
-    <Item Id="1365" Name="Wall of Flesh Trophy" />
-    <Item Id="1366" Name="Destroyer Trophy" />
-    <Item Id="1367" Name="Skeletron Prime Trophy" />
-    <Item Id="1368" Name="Retinazer Trophy" />
-    <Item Id="1369" Name="Spazmatism Trophy" />
-    <Item Id="1370" Name="Plantera Trophy" />
-    <Item Id="1371" Name="Golem Trophy" />
-    <Item Id="1372" Name="Blood Moon Rising" />
-    <Item Id="1373" Name="The Hanged Man" />
-    <Item Id="1374" Name="Glory of the Fire" />
-    <Item Id="1375" Name="Bone Warp" />
-    <Item Id="1376" Name="Wall Skeleton" />
-    <Item Id="1377" Name="Hanging Skeleton" />
-    <Item Id="1378" Name="Blue Slab Wall" />
-    <Item Id="1379" Name="Blue Tiled Wall" />
-    <Item Id="1380" Name="Pink Slab Wall" />
-    <Item Id="1381" Name="Pink Tiled Wall" />
-    <Item Id="1382" Name="Green Slab Wall" />
-    <Item Id="1383" Name="Green Tiled Wall" />
-    <Item Id="1384" Name="Blue Brick Platform" />
-    <Item Id="1385" Name="Pink Brick Platform" />
-    <Item Id="1386" Name="Green Brick Platform" />
-    <Item Id="1387" Name="Metal Shelf" />
-    <Item Id="1388" Name="Brass Shelf" />
-    <Item Id="1389" Name="Wood Shelf" />
-    <Item Id="1390" Name="Brass Lantern" />
-    <Item Id="1391" Name="Caged Lantern" />
-    <Item Id="1392" Name="Carriage Lantern" />
-    <Item Id="1393" Name="Alchemy Lantern" />
-    <Item Id="1394" Name="Diabolist Lamp" />
-    <Item Id="1395" Name="Oil Rag Sconse" />
-    <Item Id="1396" Name="Blue Dungeon Chair" />
-    <Item Id="1397" Name="Blue Dungeon Table" />
-    <Item Id="1398" Name="Blue Dungeon Work Bench" />
-    <Item Id="1399" Name="Green Dungeon Chair" />
-    <Item Id="1400" Name="Green Dungeon Table" />
-    <Item Id="1401" Name="Green Dungeon Work Bench" />
-    <Item Id="1402" Name="Pink Dungeon Chair" />
-    <Item Id="1403" Name="Pink Dungeon Table" />
-    <Item Id="1404" Name="Pink Dungeon Work Bench" />
-    <Item Id="1405" Name="Blue Dungeon Candle" />
-    <Item Id="1406" Name="Green Dungeon Candle" />
-    <Item Id="1407" Name="Pink Dungeon Candle" />
-    <Item Id="1408" Name="Blue Dungeon Vase" />
-    <Item Id="1409" Name="Green Dungeon Vase" />
-    <Item Id="1410" Name="Pink Dungeon Vase" />
-    <Item Id="1411" Name="Blue Dungeon Door" />
-    <Item Id="1412" Name="Green Dungeon Door" />
-    <Item Id="1413" Name="Pink Dungeon Door" />
-    <Item Id="1414" Name="Blue Dungeon Bookcase" />
-    <Item Id="1415" Name="Green Dungeon Bookcase" />
-    <Item Id="1416" Name="Pink Dungeon Bookcase" />
-    <Item Id="1417" Name="Catacomb" />
-    <Item Id="1418" Name="Dungeon Shelf" />
-    <Item Id="1419" Name="Skellington J Skellingsworth" />
-    <Item Id="1420" Name="The Cursed Man" />
-    <Item Id="1421" Name="The Eye Sees the End" />
-    <Item Id="1422" Name="Something Evil is Watching You" />
-    <Item Id="1423" Name="The Twins Have Awoken" />
-    <Item Id="1424" Name="The Screamer" />
-    <Item Id="1425" Name="Goblins Playing Poker" />
-    <Item Id="1426" Name="Dryadisque" />
-    <Item Id="1427" Name="Sunflowers" />
-    <Item Id="1428" Name="Terrarian Gothic" />
-    <Item Id="1429" Name="Beanie" Head="100" />
-    <Item Id="1430" Name="Imbuing Station" />
-    <Item Id="1431" Name="Star in a Bottle" />
-    <Item Id="1432" Name="Empty Bullet" />
-    <Item Id="1433" Name="Impact" />
-    <Item Id="1434" Name="Powered by Birds" />
-    <Item Id="1435" Name="The Destroyer" />
-    <Item Id="1436" Name="The Persistency of Eyes" />
-    <Item Id="1437" Name="Unicorn Crossing the Hallows" />
-    <Item Id="1438" Name="Great Wave" />
-    <Item Id="1439" Name="Starry Night" />
-    <Item Id="1440" Name="Guide Picasso" />
-    <Item Id="1441" Name="The Guardian's Gaze" />
-    <Item Id="1442" Name="Father of Someone" />
-    <Item Id="1443" Name="Nurse Lisa" />
-    <Item Id="1444" Name="Shadowbeam Staff" Rack="true" />
-    <Item Id="1445" Name="Inferno Fork" Rack="true" />
-    <Item Id="1446" Name="Spectre Staff" Rack="true" />
-    <Item Id="1447" Name="Wooden Fence" />
-    <Item Id="1448" Name="Lead Fence" />
-    <Item Id="1449" Name="Bubble Machine" />
-    <Item Id="1450" Name="Bubble Wand" />
-    <Item Id="1451" Name="Marching Bones Banner" />
-    <Item Id="1452" Name="Necromantic Sign" />
-    <Item Id="1453" Name="Rusted Company Standard" />
-    <Item Id="1454" Name="Ragged Brotherhood Sigil" />
-    <Item Id="1455" Name="Molten Legion Flag" />
-    <Item Id="1456" Name="Diabolic Sigil" />
-    <Item Id="1457" Name="Obsidian Platform" />
-    <Item Id="1458" Name="Obsidian Door" />
-    <Item Id="1459" Name="Obsidian Chair" />
-    <Item Id="1460" Name="Obsidian Table" />
-    <Item Id="1461" Name="Obsidian Work Bench" />
-    <Item Id="1462" Name="Obsidian Vase" />
-    <Item Id="1463" Name="Obsidian Bookcase" />
-    <Item Id="1464" Name="Hellbound Banner" />
-    <Item Id="1465" Name="Hell Hammer Banner" />
-    <Item Id="1466" Name="Helltower Banner" />
-    <Item Id="1467" Name="Lost Hopes of Man Banner" />
-    <Item Id="1468" Name="Obsidian Watcher Banner" />
-    <Item Id="1469" Name="Lava Erupts Banner" />
-    <Item Id="1470" Name="Blue Dungeon Bed" />
-    <Item Id="1471" Name="Green Dungeon Bed" />
-    <Item Id="1472" Name="Pink Dungeon Bed" />
-    <Item Id="1473" Name="Obsidian Bed" />
-    <Item Id="1474" Name="Waldo" />
-    <Item Id="1475" Name="Darkness" />
-    <Item Id="1476" Name="Dark Soul Reaper" />
-    <Item Id="1477" Name="Land" />
-    <Item Id="1478" Name="Trapped Ghost" />
-    <Item Id="1479" Name="Demon's Eye" />
-    <Item Id="1480" Name="Finding Gold" />
-    <Item Id="1481" Name="First Encounter" />
-    <Item Id="1482" Name="Good Morning" />
-    <Item Id="1483" Name="Underground Reward" />
-    <Item Id="1484" Name="Through the Window" />
-    <Item Id="1485" Name="Place Above the Clouds" />
-    <Item Id="1486" Name="Do Not Step on the Grass" />
-    <Item Id="1487" Name="Cold Waters in the White Land" />
-    <Item Id="1488" Name="Lightless Chasms" />
-    <Item Id="1489" Name="The Land of Deceiving Looks" />
-    <Item Id="1490" Name="Daylight" />
-    <Item Id="1491" Name="Secret of the Sands" />
-    <Item Id="1492" Name="Deadland Comes Alive" />
-    <Item Id="1493" Name="Evil Presence" />
-    <Item Id="1494" Name="Sky Guardian" />
-    <Item Id="1495" Name="American Explosive" />
-    <Item Id="1496" Name="Discover" />
-    <Item Id="1497" Name="Hand Earth" />
-    <Item Id="1498" Name="Old Miner" />
-    <Item Id="1499" Name="Skelehead" />
-    <Item Id="1500" Name="Facing the Cerebral Mastermind" />
-    <Item Id="1501" Name="Lake of Fire" />
-    <Item Id="1502" Name="Trio Super Heroes" />
-    <Item Id="1503" Name="Spectre Hood" Head="101" />
-    <Item Id="1504" Name="Spectre Robe" Body="66" />
-    <Item Id="1505" Name="Spectre Pants" Legs="55" />
-    <Item Id="1506" Name="Spectre Pickaxe" Scale="1.15" Rack="true" />
-    <Item Id="1507" Name="Spectre Hamaxe" Scale="1.05" Rack="true" />
-    <Item Id="1508" Name="Ectoplasm" />
-    <Item Id="1509" Name="Gothic Chair" />
-    <Item Id="1510" Name="Gothic Table" />
-    <Item Id="1511" Name="Gothic Work Bench" />
-    <Item Id="1512" Name="Gothic Bookcase" />
-    <Item Id="1513" Name="Paladin's Hammer" Rack="true" />
-    <Item Id="1514" Name="SWAT Helmet" Head="102" />
-    <Item Id="1515" Name="Bee Wings" />
-    <Item Id="1516" Name="Giant Harpy Feather" />
-    <Item Id="1517" Name="Bone Feather" />
-    <Item Id="1518" Name="Fire Feather" />
-    <Item Id="1519" Name="Ice Feather" />
-    <Item Id="1520" Name="Broken Bat Wing" />
-    <Item Id="1521" Name="Tattered Bee Wing" />
-    <Item Id="1522" Name="Large Amethyst" />
-    <Item Id="1523" Name="Large Topaz" />
-    <Item Id="1524" Name="Large Sapphire" />
-    <Item Id="1525" Name="Large Emerald" />
-    <Item Id="1526" Name="Large Ruby" />
-    <Item Id="1527" Name="Large Diamond" />
-    <Item Id="1528" Name="Jungle Chest" />
-    <Item Id="1529" Name="Corruption Chest" />
-    <Item Id="1530" Name="Crimson Chest" />
-    <Item Id="1531" Name="Hallowed Chest" />
-    <Item Id="1532" Name="Frozen Chest" />
-    <Item Id="1533" Name="Jungle Key" />
-    <Item Id="1534" Name="Corruption Key" />
-    <Item Id="1535" Name="Crimson Key" />
-    <Item Id="1536" Name="Hallowed Key" />
-    <Item Id="1537" Name="Frozen Key" />
-    <Item Id="1538" Name="Imp Face" />
-    <Item Id="1539" Name="Ominous Presence" />
-    <Item Id="1540" Name="Shining Moon" />
-    <Item Id="1541" Name="Living Gore" />
-    <Item Id="1542" Name="Flowing Magma" />
-    <Item Id="1543" Name="Spectre Paintbrush" />
-    <Item Id="1544" Name="Spectre Paint Roller" />
-    <Item Id="1545" Name="Spectre Paint Scraper" />
-    <Item Id="1546" Name="Shroomite Headgear" Head="103" />
-    <Item Id="1547" Name="Shroomite Mask" Head="104" />
-    <Item Id="1548" Name="Shroomite Helmet" Head="105" />
-    <Item Id="1549" Name="Shroomite Breastplate" Body="67" />
-    <Item Id="1550" Name="Shroomite Leggings" Legs="56" />
-    <Item Id="1551" Name="Autohammer" />
-    <Item Id="1552" Name="Shroomite Bar" />
-    <Item Id="1553" Name="S.D.M.G." Rack="true" />
-    <Item Id="1554" Name="Cenx's Tiara" Head="106" />
-    <Item Id="1555" Name="Cenx's Breastplate" Body="68" />
-    <Item Id="1556" Name="Cenx's Leggings" Legs="57" />
-    <Item Id="1557" Name="Crowno's Mask" Head="107" />
-    <Item Id="1558" Name="Crowno's Breastplate" Body="69" />
-    <Item Id="1559" Name="Crowno's Leggings" Legs="58" />
-    <Item Id="1560" Name="Will's Helmet" Head="108" />
-    <Item Id="1561" Name="Will's Breastplate" Body="70" />
-    <Item Id="1562" Name="Will's Leggings" Legs="59" />
-    <Item Id="1563" Name="Jim's Helmet" Head="109" />
-    <Item Id="1564" Name="Jim's Breastplate" Body="71" />
-    <Item Id="1565" Name="Jim's Leggings" Legs="60" />
-    <Item Id="1566" Name="Aaron's Helmet" Head="110" />
-    <Item Id="1567" Name="Aaron's Breastplate" Body="72" />
-    <Item Id="1568" Name="Aaron's Leggings" Legs="61" />
-    <Item Id="1569" Name="Vampire Knives" Rack="true" />
-    <Item Id="1570" Name="Broken Hero Sword" />
-    <Item Id="1571" Name="Scourge of the Corruptor" Rack="true" />
-    <Item Id="1572" Name="Staff of the Frost Hydra" Rack="true" />
-    <Item Id="1573" Name="The Creation of the Guide" />
-    <Item Id="1574" Name="The Merchant" />
-    <Item Id="1575" Name="Crowno Devours His Lunch" />
-    <Item Id="1576" Name="Rare Enchantment" />
-    <Item Id="1577" Name="Glorious Night" />
-    <Item Id="1578" Name="Sweetheart Necklace" />
-    <Item Id="1579" Name="Flurry Boots" />
-    <Item Id="1580" Name="D-Town's Helmet" Head="111" />
-    <Item Id="1581" Name="D-Town's Breastplate" Body="73" />
-    <Item Id="1582" Name="D-Town's Leggings" Legs="62" />
-    <Item Id="1583" Name="D-Town's Wings" />
-    <Item Id="1584" Name="Will's Wings" />
-    <Item Id="1585" Name="Crowno's Wings" />
-    <Item Id="1586" Name="Cenx's Wings" />
-    <Item Id="1587" Name="Cenx's Dress" Body="74" />
-    <Item Id="1588" Name="Cenx's Dress Pants" Legs="63" />
-    <Item Id="1589" Name="Palladium Column" />
-    <Item Id="1590" Name="Palladium Column Wall" />
-    <Item Id="1591" Name="Bubblegum Block" />
-    <Item Id="1592" Name="Bubblegum Block Wall" />
-    <Item Id="1593" Name="Titanstone Block" />
-    <Item Id="1594" Name="Titanstone Block Wall" />
-    <Item Id="1595" Name="Magic Cuffs" />
-    <Item Id="1596" Name="Music Box (Snow)" />
-    <Item Id="1597" Name="Music Box (Space)" />
-    <Item Id="1598" Name="Music Box (Crimson)" />
-    <Item Id="1599" Name="Music Box (Boss 4)" />
-    <Item Id="1600" Name="Music Box (Alt Overworld Day)" />
-    <Item Id="1601" Name="Music Box (Rain)" />
-    <Item Id="1602" Name="Music Box (Ice)" />
-    <Item Id="1603" Name="Music Box (Desert)" />
-    <Item Id="1604" Name="Music Box (Ocean)" />
-    <Item Id="1605" Name="Music Box (Dungeon)" />
-    <Item Id="1606" Name="Music Box (Plantera)" />
-    <Item Id="1607" Name="Music Box (Boss 5)" />
-    <Item Id="1608" Name="Music Box (Temple)" />
-    <Item Id="1609" Name="Music Box (Eclipse)" />
-    <Item Id="1610" Name="Music Box (Mushrooms)" />
-    <Item Id="1611" Name="Butterfly Dust" />
-    <Item Id="1612" Name="Ankh Charm" />
-    <Item Id="1613" Name="Ankh Shield" />
-    <Item Id="1614" Name="Blue Flare" Rack="true" />
-    <Item Id="1615" Name="Angler Fish Banner" Tally="1" />
-    <Item Id="1616" Name="Angry Nimbus Banner" Tally="2" />
-    <Item Id="1617" Name="Anomura Fungus Banner" Tally="3" />
-    <Item Id="1618" Name="Antlion Banner" Tally="4" />
-    <Item Id="1619" Name="Arapaima Banner" Tally="5" />
-    <Item Id="1620" Name="Armored Skeleton Banner" Tally="6" />
-    <Item Id="1621" Name="Cave Bat Banner" Tally="7" />
-    <Item Id="1622" Name="Bird Banner" Tally="8" />
-    <Item Id="1623" Name="Black Recluse Banner" Tally="9" />
-    <Item Id="1624" Name="Blood Feeder Banner" Tally="10" />
-    <Item Id="1625" Name="Blood Jelly Banner" Tally="11" />
-    <Item Id="1626" Name="Blood Crawler Banner" Tally="12" />
-    <Item Id="1627" Name="Bone Serpent Banner" Tally="13" />
-    <Item Id="1628" Name="Bunny Banner" Tally="14" />
-    <Item Id="1629" Name="Chaos Elemental Banner" Tally="15" />
-    <Item Id="1630" Name="Mimic Banner" Tally="16" />
-    <Item Id="1631" Name="Clown Banner" Tally="17" />
-    <Item Id="1632" Name="Corrupt Bunny Banner" Tally="18" />
-    <Item Id="1633" Name="Corrupt Goldfish Banner" Tally="19" />
-    <Item Id="1634" Name="Crab Banner" Tally="20" />
-    <Item Id="1635" Name="Crimera Banner" Tally="21" />
-    <Item Id="1636" Name="Crimson Axe Banner" Tally="22" />
-    <Item Id="1637" Name="Cursed Hammer Banner" Tally="23" />
-    <Item Id="1638" Name="Demon Banner" Tally="24" />
-    <Item Id="1639" Name="Demon Eye Banner" Tally="25" />
-    <Item Id="1640" Name="Derpling Banner" Tally="26" />
-    <Item Id="1641" Name="Eater of Souls Banner" Tally="27" />
-    <Item Id="1642" Name="Enchanted Sword Banner" Tally="28" />
-    <Item Id="1643" Name="Zombie Eskimo Banner" Tally="29" />
-    <Item Id="1644" Name="Face Monster Banner" Tally="30" />
-    <Item Id="1645" Name="Floaty Gross Banner" Tally="31" />
-    <Item Id="1646" Name="Flying Fish Banner" Tally="32" />
-    <Item Id="1647" Name="Flying Snake Banner" Tally="33" />
-    <Item Id="1648" Name="Frankenstein Banner" Tally="34" />
-    <Item Id="1649" Name="Fungi Bulb Banner" Tally="35" />
-    <Item Id="1650" Name="Fungo Fish Banner" Tally="36" />
-    <Item Id="1651" Name="Gastropod Banner" Tally="37" />
-    <Item Id="1652" Name="Goblin Thief Banner" Tally="38" />
-    <Item Id="1653" Name="Goblin Sorcerer Banner" Tally="39" />
-    <Item Id="1654" Name="Goblin Peon Banner" Tally="40" />
-    <Item Id="1655" Name="Goblin Scout Banner" Tally="41" />
-    <Item Id="1656" Name="Goblin Warrior Banner" Tally="42" />
-    <Item Id="1657" Name="Goldfish Banner" Tally="43" />
-    <Item Id="1658" Name="Harpy Banner" Tally="44" />
-    <Item Id="1659" Name="Hellbat Banner" Tally="45" />
-    <Item Id="1660" Name="Herpling Banner" Tally="46" />
-    <Item Id="1661" Name="Hornet Banner" Tally="47" />
-    <Item Id="1662" Name="Ice Elemental Banner" Tally="48" />
-    <Item Id="1663" Name="Icy Merman Banner" Tally="49" />
-    <Item Id="1664" Name="Fire Imp Banner" Tally="50" />
-    <Item Id="1665" Name="Blue Jellyfish Banner" Tally="51" />
-    <Item Id="1666" Name="Jungle Creeper Banner" Tally="52" />
-    <Item Id="1667" Name="Lihzahrd Banner" Tally="53" />
-    <Item Id="1668" Name="Man Eater Banner" Tally="54" />
-    <Item Id="1669" Name="Meteor Head Banner" Tally="55" />
-    <Item Id="1670" Name="Moth Banner" Tally="56" />
-    <Item Id="1671" Name="Mummy Banner" Tally="57" />
-    <Item Id="1672" Name="Mushi Ladybug Banner" Tally="58" />
-    <Item Id="1673" Name="Parrot Banner" Tally="59" />
-    <Item Id="1674" Name="Pigron Banner" Tally="60" />
-    <Item Id="1675" Name="Piranha Banner" Tally="61" />
-    <Item Id="1676" Name="Pirate Deckhand Banner" Tally="62" />
-    <Item Id="1677" Name="Pixie Banner" Tally="63" />
-    <Item Id="1678" Name="Raincoat Zombie Banner" Tally="64" />
-    <Item Id="1679" Name="Reaper Banner" Tally="65" />
-    <Item Id="1680" Name="Shark Banner" Tally="66" />
-    <Item Id="1681" Name="Skeleton Banner" Tally="67" />
-    <Item Id="1682" Name="Dark Caster Banner" Tally="68" />
-    <Item Id="1683" Name="Blue Slime Banner" Tally="69" />
-    <Item Id="1684" Name="Snow Flinx Banner" Tally="70" />
-    <Item Id="1685" Name="Wall Creeper Banner" Tally="71" />
-    <Item Id="1686" Name="Spore Zombie Banner" Tally="72" />
-    <Item Id="1687" Name="Swamp Thing Banner" Tally="73" />
-    <Item Id="1688" Name="Giant Tortoise Banner" Tally="74" />
-    <Item Id="1689" Name="Toxic Sludge Banner" Tally="75" />
-    <Item Id="1690" Name="Umbrella Slime Banner" Tally="76" />
-    <Item Id="1691" Name="Unicorn Banner" Tally="77" />
-    <Item Id="1692" Name="Vampire Banner" Tally="78" />
-    <Item Id="1693" Name="Vulture Banner" Tally="79" />
-    <Item Id="1694" Name="Nymph Banner" Tally="80" />
-    <Item Id="1695" Name="Werewolf Banner" Tally="81" />
-    <Item Id="1696" Name="Wolf Banner" Tally="82" />
-    <Item Id="1697" Name="World Feeder Banner" Tally="83" />
-    <Item Id="1698" Name="Worm Banner" Tally="84" />
-    <Item Id="1699" Name="Wraith Banner" Tally="85" />
-    <Item Id="1700" Name="Wyvern Banner" Tally="86" />
-    <Item Id="1701" Name="Zombie Banner" Tally="87" />
-    <Item Id="1702" Name="Glass Platform" />
-    <Item Id="1703" Name="Glass Chair" />
-    <Item Id="1704" Name="Golden Chair" />
-    <Item Id="1705" Name="Golden Toilet" />
-    <Item Id="1706" Name="Bar Stool" />
-    <Item Id="1707" Name="Honey Chair" />
-    <Item Id="1708" Name="Steampunk Chair" />
-    <Item Id="1709" Name="Glass Door" />
-    <Item Id="1710" Name="Golden Door" />
-    <Item Id="1711" Name="Honey Door" />
-    <Item Id="1712" Name="Steampunk Door" />
-    <Item Id="1713" Name="Glass Table" />
-    <Item Id="1714" Name="Banquet Table" />
-    <Item Id="1715" Name="Bar" />
-    <Item Id="1716" Name="Golden Table" />
-    <Item Id="1717" Name="Honey Table" />
-    <Item Id="1718" Name="Steampunk Table" />
-    <Item Id="1719" Name="Glass Bed" />
-    <Item Id="1720" Name="Golden Bed" />
-    <Item Id="1721" Name="Honey Bed" />
-    <Item Id="1722" Name="Steampunk Bed" />
-    <Item Id="1723" Name="Living Wood Wall" />
-    <Item Id="1724" Name="Fart in a Jar" />
-    <Item Id="1725" Name="Pumpkin" />
-    <Item Id="1726" Name="Pumpkin Wall" />
-    <Item Id="1727" Name="Hay" />
-    <Item Id="1728" Name="Hay Wall" />
-    <Item Id="1729" Name="Spooky Wood" />
-    <Item Id="1730" Name="Spooky Wood Wall" />
-    <Item Id="1731" Name="Pumpkin Helmet" Head="112" />
-    <Item Id="1732" Name="Pumpkin Breastplate" Body="75" />
-    <Item Id="1733" Name="Pumpkin Leggings" Legs="64" />
-    <Item Id="1734" Name="Candy Apple" />
-    <Item Id="1735" Name="Soul Cake" />
-    <Item Id="1736" Name="Nurse Hat" Head="113" />
-    <Item Id="1737" Name="Nurse Shirt" Body="76" />
-    <Item Id="1738" Name="Nurse Pants" Legs="65" />
-    <Item Id="1739" Name="Wizard's Hat" Head="114" />
-    <Item Id="1740" Name="Guy Fawkes Mask" Head="115" />
-    <Item Id="1741" Name="Dye Trader Robe" Body="77" />
-    <Item Id="1742" Name="Steampunk Goggles" Head="116" />
-    <Item Id="1743" Name="Cyborg Helmet" Head="117" />
-    <Item Id="1744" Name="Cyborg Shirt" Body="78" />
-    <Item Id="1745" Name="Cyborg Pants" Legs="66" />
-    <Item Id="1746" Name="Creeper Mask" Head="118" />
-    <Item Id="1747" Name="Creeper Shirt" Body="79" />
-    <Item Id="1748" Name="Creeper Pants" Legs="67" />
-    <Item Id="1749" Name="Cat Mask" Head="119" />
-    <Item Id="1750" Name="Cat Shirt" Body="80" />
-    <Item Id="1751" Name="Cat Pants" Legs="68" />
-    <Item Id="1752" Name="Ghost Mask" Head="120" />
-    <Item Id="1753" Name="Ghost Shirt" Body="81" />
-    <Item Id="1754" Name="Pumpkin Mask" Head="121" />
-    <Item Id="1755" Name="Pumpkin Shirt" Body="82" />
-    <Item Id="1756" Name="Pumpkin Pants" Legs="69" />
-    <Item Id="1757" Name="Robot Mask" Head="122" />
-    <Item Id="1758" Name="Robot Shirt" Body="83" />
-    <Item Id="1759" Name="Robot Pants" Legs="70" />
-    <Item Id="1760" Name="Unicorn Mask" Head="123" />
-    <Item Id="1761" Name="Unicorn Shirt" Body="84" />
-    <Item Id="1762" Name="Unicorn Pants" Legs="71" />
-    <Item Id="1763" Name="Vampire Mask" Head="124" />
-    <Item Id="1764" Name="Vampire Shirt" Body="85" />
-    <Item Id="1765" Name="Vampire Pants" Legs="72" />
-    <Item Id="1766" Name="Witch Hat" Head="125" />
-    <Item Id="1767" Name="Leprechaun Hat" Head="126" />
-    <Item Id="1768" Name="Leprechaun Shirt" Body="86" />
-    <Item Id="1769" Name="Leprechaun Pants" Legs="73" />
-    <Item Id="1770" Name="Pixie Shirt" Body="87" />
-    <Item Id="1771" Name="Pixie Pants" Legs="74" />
-    <Item Id="1772" Name="Princess Hat" Head="127" />
-    <Item Id="1773" Name="Princess Dress" Body="88" />
-    <Item Id="1774" Name="Goodie Bag" />
-    <Item Id="1775" Name="Witch Dress" Body="89" />
-    <Item Id="1776" Name="Witch Boots" Legs="75" />
-    <Item Id="1777" Name="Bride of Frankenstein Mask" Head="128" />
-    <Item Id="1778" Name="Bride of Frankenstein Dress" Body="90" />
-    <Item Id="1779" Name="Karate Tortoise Mask" Head="129" />
-    <Item Id="1780" Name="Karate Tortoise Shirt" Body="91" />
-    <Item Id="1781" Name="Karate Tortoise Pants" Legs="76" />
-    <Item Id="1782" Name="Candy Corn Rifle" Rack="true" />
-    <Item Id="1783" Name="Candy Corn" Rack="true" />
-    <Item Id="1784" Name="Jack 'O Lantern Launcher" Rack="true" />
-    <Item Id="1785" Name="Explosive Jack 'O Lantern" Rack="true" />
-    <Item Id="1786" Name="Sickle" Rack="true" />
-    <Item Id="1787" Name="Pumpkin Pie" />
-    <Item Id="1788" Name="Scarecrow Hat" Head="130" />
-    <Item Id="1789" Name="Scarecrow Shirt" Body="92" />
-    <Item Id="1790" Name="Scarecrow Pants" Legs="77" />
-    <Item Id="1791" Name="Cauldron" />
-    <Item Id="1792" Name="Pumpkin Chair" />
-    <Item Id="1793" Name="Pumpkin Door" />
-    <Item Id="1794" Name="Pumpkin Table" />
-    <Item Id="1795" Name="Pumpkin Work Bench" />
-    <Item Id="1796" Name="Pumpkin Platform" />
-    <Item Id="1797" Name="Tattered Fairy Wings" />
-    <Item Id="1798" Name="Spider Egg" />
-    <Item Id="1799" Name="Magical Pumpkin Seed" />
-    <Item Id="1800" Name="Bat Hook" />
-    <Item Id="1801" Name="Bat Scepter" Rack="true" />
-    <Item Id="1802" Name="Raven Staff" />
-    <Item Id="1803" Name="Jungle Key Mold" />
-    <Item Id="1804" Name="Corruption Key Mold" />
-    <Item Id="1805" Name="Crimson Key Mold" />
-    <Item Id="1806" Name="Hallowed Key Mold" />
-    <Item Id="1807" Name="Frozen Key Mold" />
-    <Item Id="1808" Name="Hanging Jack 'O Lantern" />
-    <Item Id="1809" Name="Rotten Egg" Rack="true" />
-    <Item Id="1810" Name="Unlucky Yarn" />
-    <Item Id="1811" Name="Black Fairy Dust" />
-    <Item Id="1812" Name="Jackelier" />
-    <Item Id="1813" Name="Jack 'O Lantern" />
-    <Item Id="1814" Name="Spooky Chair" />
-    <Item Id="1815" Name="Spooky Door" />
-    <Item Id="1816" Name="Spooky Table" />
-    <Item Id="1817" Name="Spooky Work Bench" />
-    <Item Id="1818" Name="Spooky Platform" />
-    <Item Id="1819" Name="Reaper Hood" Head="131" />
-    <Item Id="1820" Name="Reaper Robe" Body="93" />
-    <Item Id="1821" Name="Fox Mask" Head="132" />
-    <Item Id="1822" Name="Fox Shirt" Body="94" />
-    <Item Id="1823" Name="Fox Pants" Legs="78" />
-    <Item Id="1824" Name="Cat Ears" Head="133" />
-    <Item Id="1825" Name="Bloody Machete" Rack="true" />
-    <Item Id="1826" Name="The Horseman's Blade" Scale="1.15" Rack="true" />
-    <Item Id="1827" Name="Bladed Glove" Scale="1.35" Rack="true" />
-    <Item Id="1828" Name="Pumpkin Seed" />
-    <Item Id="1829" Name="Spooky Hook" />
-    <Item Id="1830" Name="Spooky Wings" />
-    <Item Id="1831" Name="Spooky Twig" />
-    <Item Id="1832" Name="Spooky Helmet" Head="134" />
-    <Item Id="1833" Name="Spooky Breastplate" Body="95" />
-    <Item Id="1834" Name="Spooky Leggings" Legs="79" />
-    <Item Id="1835" Name="Stake Launcher" Rack="true" />
-    <Item Id="1836" Name="Stake" Rack="true" />
-    <Item Id="1837" Name="Cursed Sapling" />
-    <Item Id="1838" Name="Space Creature Mask" Head="135" />
-    <Item Id="1839" Name="Space Creature Shirt" Body="96" />
-    <Item Id="1840" Name="Space Creature Pants" Legs="80" />
-    <Item Id="1841" Name="Wolf Mask" Head="136" />
-    <Item Id="1842" Name="Wolf Shirt" Body="97" />
-    <Item Id="1843" Name="Wolf Pants" Legs="81" />
-    <Item Id="1844" Name="Pumpkin Moon Medallion" />
-    <Item Id="1845" Name="Necromantic Scroll" />
-    <Item Id="1846" Name="Jacking Skeletron" />
-    <Item Id="1847" Name="Bitter Harvest" />
-    <Item Id="1848" Name="Blood Moon Countess" />
-    <Item Id="1849" Name="Hallow's Eve" />
-    <Item Id="1850" Name="Morbid Curiosity" />
-    <Item Id="1851" Name="Treasure Hunter Shirt" Body="98" />
-    <Item Id="1852" Name="Treasure Hunter Pants" Legs="82" />
-    <Item Id="1853" Name="Dryad Coverings" Body="99" />
-    <Item Id="1854" Name="Dryad Loincloth" Legs="83" />
-    <Item Id="1855" Name="Mourning Wood Trophy" />
-    <Item Id="1856" Name="Pumpking Trophy" />
-    <Item Id="1857" Name="Jack 'O Lantern Mask" Head="137" />
-    <Item Id="1858" Name="Sniper Scope" />
-    <Item Id="1859" Name="Heart Lantern" />
-    <Item Id="1860" Name="Jellyfish Diving Gear" />
-    <Item Id="1861" Name="Arctic Diving Gear" />
-    <Item Id="1862" Name="Frostspark Boots" />
-    <Item Id="1863" Name="Fart in a Balloon" />
-    <Item Id="1864" Name="Papyrus Scarab" />
-    <Item Id="1865" Name="Celestial Stone" />
-    <Item Id="1866" Name="Hoverboard" />
-    <Item Id="1867" Name="Candy Cane" />
-    <Item Id="1868" Name="Sugar Plum" />
-    <Item Id="1869" Name="Present" />
-    <Item Id="1870" Name="Red Ryder" Rack="true" />
-    <Item Id="1871" Name="Festive Wings" />
-    <Item Id="1872" Name="Pine Tree Block" />
-    <Item Id="1873" Name="Christmas Tree" />
-    <Item Id="1874" Name="Star Topper 1" />
-    <Item Id="1875" Name="Star Topper 2" />
-    <Item Id="1876" Name="Star Topper 3" />
-    <Item Id="1877" Name="Bow Topper" />
-    <Item Id="1878" Name="White Garland" />
-    <Item Id="1879" Name="White and Red Garland" />
-    <Item Id="1880" Name="Red Garland" />
-    <Item Id="1881" Name="Red and Green Garland" />
-    <Item Id="1882" Name="Green Garland" />
-    <Item Id="1883" Name="Green and White Garland" />
-    <Item Id="1884" Name="Multicolored Bulb" />
-    <Item Id="1885" Name="Red Bulb" />
-    <Item Id="1886" Name="Yellow Bulb" />
-    <Item Id="1887" Name="Green Bulb" />
-    <Item Id="1888" Name="Red and Green Bulb" />
-    <Item Id="1889" Name="Yellow and Green Bulb" />
-    <Item Id="1890" Name="Red and Yellow Bulb" />
-    <Item Id="1891" Name="White Bulb" />
-    <Item Id="1892" Name="White and Red Bulb" />
-    <Item Id="1893" Name="White and Yellow Bulb" />
-    <Item Id="1894" Name="White and Green Bulb" />
-    <Item Id="1895" Name="Multicolored Lights" />
-    <Item Id="1896" Name="Red Lights" />
-    <Item Id="1897" Name="Green Lights" />
-    <Item Id="1898" Name="Blue Lights" />
-    <Item Id="1899" Name="Yellow Lights" />
-    <Item Id="1900" Name="Red and Yellow Lights" />
-    <Item Id="1901" Name="Red and Green Lights" />
-    <Item Id="1902" Name="Yellow and Green Lights" />
-    <Item Id="1903" Name="Blue and Green Lights" />
-    <Item Id="1904" Name="Red and Blue Lights" />
-    <Item Id="1905" Name="Blue and Yellow Lights" />
-    <Item Id="1906" Name="Giant Bow" Head="138" />
-    <Item Id="1907" Name="Reindeer Antlers" Head="139" />
-    <Item Id="1908" Name="Holly" />
-    <Item Id="1909" Name="Candy Cane Sword" Scale="1.1" Rack="true" />
-    <Item Id="1910" Name="Elf Melter" Rack="true" />
-    <Item Id="1911" Name="Christmas Pudding" />
-    <Item Id="1912" Name="Eggnog" />
-    <Item Id="1913" Name="Star Anise" Rack="true" />
-    <Item Id="1914" Name="Reindeer Bells" />
-    <Item Id="1915" Name="Candy Cane Hook" />
-    <Item Id="1916" Name="Christmas Hook" />
-    <Item Id="1917" Name="Candy Cane Pickaxe" Rack="true" />
-    <Item Id="1918" Name="Fruitcake Chakram" Rack="true" />
-    <Item Id="1919" Name="Sugar Cookie" />
-    <Item Id="1920" Name="Gingerbread Cookie" />
-    <Item Id="1921" Name="Hand Warmer" />
-    <Item Id="1922" Name="Coal" />
-    <Item Id="1923" Name="Toolbox" />
-    <Item Id="1924" Name="Pine Door" />
-    <Item Id="1925" Name="Pine Chair" />
-    <Item Id="1926" Name="Pine Table" />
-    <Item Id="1927" Name="Dog Whistle" />
-    <Item Id="1928" Name="Christmas Tree Sword" Scale="1.1" Rack="true" />
-    <Item Id="1929" Name="Chain Gun" Rack="true" />
-    <Item Id="1930" Name="Razorpine" Rack="true" />
-    <Item Id="1931" Name="Blizzard Staff" Rack="true" />
-    <Item Id="1932" Name="Mrs. Claus Hat" Head="140" />
-    <Item Id="1933" Name="Mrs. Claus Shirt" Body="100" />
-    <Item Id="1934" Name="Mrs. Claus Heels" Legs="84" />
-    <Item Id="1935" Name="Parka Hood" Head="142" />
-    <Item Id="1936" Name="Parka Coat" Body="102" />
-    <Item Id="1937" Name="Parka Pants" Legs="86" />
-    <Item Id="1938" Name="Snow Hat" Head="143" />
-    <Item Id="1939" Name="Ugly Sweater" Body="103" />
-    <Item Id="1940" Name="Tree Mask" Head="141" />
-    <Item Id="1941" Name="Tree Shirt" Body="101" />
-    <Item Id="1942" Name="Tree Trunks" Legs="85" />
-    <Item Id="1943" Name="Elf Hat" Head="144" />
-    <Item Id="1944" Name="Elf Shirt" Body="104" />
-    <Item Id="1945" Name="Elf Pants" Legs="87" />
-    <Item Id="1946" Name="Snowman Cannon" Rack="true" />
-    <Item Id="1947" Name="North Pole" Scale="1.1" Rack="true" />
-    <Item Id="1948" Name="Christmas Tree Wallpaper" />
-    <Item Id="1949" Name="Ornament Wallpaper" />
-    <Item Id="1950" Name="Candy Cane Wallpaper" />
-    <Item Id="1951" Name="Festive Wallpaper" />
-    <Item Id="1952" Name="Stars Wallpaper" />
-    <Item Id="1953" Name="Squiggles Wallpaper" />
-    <Item Id="1954" Name="Snowflake Wallpaper" />
-    <Item Id="1955" Name="Krampus Horn Wallpaper" />
-    <Item Id="1956" Name="Bluegreen Wallpaper" />
-    <Item Id="1957" Name="Grinch Finger Wallpaper" />
-    <Item Id="1958" Name="Naughty Present" />
-    <Item Id="1959" Name="Baby Grinch's Mischief Whistle" />
-    <Item Id="1960" Name="Ice Queen Trophy" />
-    <Item Id="1961" Name="Santa-NK1 Trophy" />
-    <Item Id="1962" Name="Everscream Trophy" />
-    <Item Id="1963" Name="Music Box (Pumpkin Moon)" />
-    <Item Id="1964" Name="Music Box (Alt Underground)" />
-    <Item Id="1965" Name="Music Box (Frost Moon)" />
-    <Item Id="1966" Name="Brown Paint" />
-    <Item Id="1967" Name="Shadow Paint" />
-    <Item Id="1968" Name="Negative Paint" />
-    <Item Id="1969" Name="Team Dye" />
-    <Item Id="1970" Name="Amethyst Gemspark Block" />
-    <Item Id="1971" Name="Topaz Gemspark Block" />
-    <Item Id="1972" Name="Sapphire Gemspark Block" />
-    <Item Id="1973" Name="Emerald Gemspark Block" />
-    <Item Id="1974" Name="Ruby Gemspark Block" />
-    <Item Id="1975" Name="Diamond Gemspark Block" />
-    <Item Id="1976" Name="Amber Gemspark Block" />
-    <Item Id="1977" Name="Life Hair Dye" />
-    <Item Id="1978" Name="Mana Hair Dye" />
-    <Item Id="1979" Name="Depth Hair Dye" />
-    <Item Id="1980" Name="Money Hair Dye" />
-    <Item Id="1981" Name="Time Hair Dye" />
-    <Item Id="1982" Name="Team Hair Dye" />
-    <Item Id="1983" Name="Biome Hair Dye" />
-    <Item Id="1984" Name="Party Hair Dye" />
-    <Item Id="1985" Name="Rainbow Hair Dye" />
-    <Item Id="1986" Name="Speed Hair Dye" />
-    <Item Id="1987" Name="Angel Halo" />
-    <Item Id="1988" Name="Fez" Head="145" />
-    <Item Id="1989" Name="Womannequin" />
-    <Item Id="1990" Name="Hair Dye Remover" />
-    <Item Id="1991" Name="Bug Net" />
-    <Item Id="1992" Name="Firefly" />
-    <Item Id="1993" Name="Firefly in a Bottle" />
-    <Item Id="1994" Name="Monarch Butterfly" />
-    <Item Id="1995" Name="Purple Emperor Butterfly" />
-    <Item Id="1996" Name="Red Admiral Butterfly" />
-    <Item Id="1997" Name="Ulysses Butterfly" />
-    <Item Id="1998" Name="Sulphur Butterfly" />
-    <Item Id="1999" Name="Tree Nymph Butterfly" />
-    <Item Id="2000" Name="Zebra Swallowtail Butterfly" />
-    <Item Id="2001" Name="Julia Butterfly" />
-    <Item Id="2002" Name="Worm" />
-    <Item Id="2003" Name="Mouse" />
-    <Item Id="2004" Name="Lightning Bug" />
-    <Item Id="2005" Name="Lightning Bug in a Bottle" />
-    <Item Id="2006" Name="Snail" />
-    <Item Id="2007" Name="Glowing Snail" />
-    <Item Id="2008" Name="Fancy Gray Wallpaper" />
-    <Item Id="2009" Name="Ice Floe Wallpaper" />
-    <Item Id="2010" Name="Music Wallpaper" />
-    <Item Id="2011" Name="Purple Rain Wallpaper" />
-    <Item Id="2012" Name="Rainbow Wallpaper" />
-    <Item Id="2013" Name="Sparkle Stone Wallpaper" />
-    <Item Id="2014" Name="Starlit Heaven Wallpaper" />
-    <Item Id="2015" Name="Bird" />
-    <Item Id="2016" Name="Blue Jay" />
-    <Item Id="2017" Name="Cardinal" />
-    <Item Id="2018" Name="Squirrel" />
-    <Item Id="2019" Name="Bunny" />
-    <Item Id="2020" Name="Cactus Bookcase" />
-    <Item Id="2021" Name="Ebonwood Bookcase" />
-    <Item Id="2022" Name="Flesh Bookcase" />
-    <Item Id="2023" Name="Honey Bookcase" />
-    <Item Id="2024" Name="Steampunk Bookcase" />
-    <Item Id="2025" Name="Glass Bookcase" />
-    <Item Id="2026" Name="Rich Mahogany Bookcase" />
-    <Item Id="2027" Name="Pearlwood Bookcase" />
-    <Item Id="2028" Name="Spooky Bookcase" />
-    <Item Id="2029" Name="Skyware Bookcase" />
-    <Item Id="2030" Name="Lihzahrd Bookcase" />
-    <Item Id="2031" Name="Frozen Bookcase" />
-    <Item Id="2032" Name="Cactus Lantern" />
-    <Item Id="2033" Name="Ebonwood Lantern" />
-    <Item Id="2034" Name="Flesh Lantern" />
-    <Item Id="2035" Name="Honey Lantern" />
-    <Item Id="2036" Name="Steampunk Lantern" />
-    <Item Id="2037" Name="Glass Lantern" />
-    <Item Id="2038" Name="Rich Mahogany Lantern" />
-    <Item Id="2039" Name="Pearlwood Lantern" />
-    <Item Id="2040" Name="Frozen Lantern" />
-    <Item Id="2041" Name="Lihzahrd Lantern" />
-    <Item Id="2042" Name="Skyware Lantern" />
-    <Item Id="2043" Name="Spooky Lantern" />
-    <Item Id="2044" Name="Frozen Door" />
-    <Item Id="2045" Name="Cactus Candle" />
-    <Item Id="2046" Name="Ebonwood Candle" />
-    <Item Id="2047" Name="Flesh Candle" />
-    <Item Id="2048" Name="Glass Candle" />
-    <Item Id="2049" Name="Frozen Candle" />
-    <Item Id="2050" Name="Rich Mahogany Candle" />
-    <Item Id="2051" Name="Pearlwood Candle" />
-    <Item Id="2052" Name="Lihzahrd Candle" />
-    <Item Id="2053" Name="Skyware Candle" />
-    <Item Id="2054" Name="Pumpkin Candle" />
-    <Item Id="2055" Name="Cactus Chandelier" />
-    <Item Id="2056" Name="Ebonwood Chandelier" />
-    <Item Id="2057" Name="Flesh Chandelier" />
-    <Item Id="2058" Name="Honey Chandelier" />
-    <Item Id="2059" Name="Frozen Chandelier" />
-    <Item Id="2060" Name="Rich Mahogany Chandelier" />
-    <Item Id="2061" Name="Pearlwood Chandelier" />
-    <Item Id="2062" Name="Lihzahrd Chandelier" />
-    <Item Id="2063" Name="Skyware Chandelier" />
-    <Item Id="2064" Name="Spooky Chandelier" />
-    <Item Id="2065" Name="Glass Chandelier" />
-    <Item Id="2066" Name="Cactus Bed" />
-    <Item Id="2067" Name="Flesh Bed" />
-    <Item Id="2068" Name="Frozen Bed" />
-    <Item Id="2069" Name="Lihzahrd Bed" />
-    <Item Id="2070" Name="Skyware Bed" />
-    <Item Id="2071" Name="Spooky Bed" />
-    <Item Id="2072" Name="Cactus Bathtub" />
-    <Item Id="2073" Name="Ebonwood Bathtub" />
-    <Item Id="2074" Name="Flesh Bathtub" />
-    <Item Id="2075" Name="Glass Bathtub" />
-    <Item Id="2076" Name="Frozen Bathtub" />
-    <Item Id="2077" Name="Rich Mahogany Bathtub" />
-    <Item Id="2078" Name="Pearlwood Bathtub" />
-    <Item Id="2079" Name="Lihzahrd Bathtub" />
-    <Item Id="2080" Name="Skyware Bathtub" />
-    <Item Id="2081" Name="Spooky Bathtub" />
-    <Item Id="2082" Name="Cactus Lamp" />
-    <Item Id="2083" Name="Ebonwood Lamp" />
-    <Item Id="2084" Name="Flesh Lamp" />
-    <Item Id="2085" Name="Glass Lamp" />
-    <Item Id="2086" Name="Frozen Lamp" />
-    <Item Id="2087" Name="Rich Mahogany Lamp" />
-    <Item Id="2088" Name="Pearlwood Lamp" />
-    <Item Id="2089" Name="Lihzahrd Lamp" />
-    <Item Id="2090" Name="Skyware Lamp" />
-    <Item Id="2091" Name="Spooky Lamp" />
-    <Item Id="2092" Name="Cactus Candelabra" />
-    <Item Id="2093" Name="Ebonwood Candelabra" />
-    <Item Id="2094" Name="Flesh Candelabra" />
-    <Item Id="2095" Name="Honey Candelabra" />
-    <Item Id="2096" Name="Steampunk Candelabra" />
-    <Item Id="2097" Name="Glass Candelabra" />
-    <Item Id="2098" Name="Rich Mahogany Candelabra" />
-    <Item Id="2099" Name="Pearlwood Candelabra" />
-    <Item Id="2100" Name="Frozen Candelabra" />
-    <Item Id="2101" Name="Lihzahrd Candelabra" />
-    <Item Id="2102" Name="Skyware Candelabra" />
-    <Item Id="2103" Name="Spooky Candelabra" />
-    <Item Id="2104" Name="Brain of Cthulhu Mask" Head="146" />
-    <Item Id="2105" Name="Wall of Flesh Mask" Head="147" />
-    <Item Id="2106" Name="Twin Mask" Head="148" />
-    <Item Id="2107" Name="Skeletron Prime Mask" Head="149" />
-    <Item Id="2108" Name="Queen Bee Mask" Head="150" />
-    <Item Id="2109" Name="Plantera Mask" Head="151" />
-    <Item Id="2110" Name="Golem Mask" Head="152" />
-    <Item Id="2111" Name="Eater of Worlds Mask" Head="153" />
-    <Item Id="2112" Name="Eye of Cthulhu Mask" Head="154" />
-    <Item Id="2113" Name="Destroyer Mask" Head="155" />
-    <Item Id="2114" Name="Blacksmith Rack" />
-    <Item Id="2115" Name="Carpentry Rack" />
-    <Item Id="2116" Name="Helmet Rack" />
-    <Item Id="2117" Name="Spear Rack" />
-    <Item Id="2118" Name="Sword Rack" />
-    <Item Id="2119" Name="Stone Slab" />
-    <Item Id="2120" Name="Sandstone Slab" />
-    <Item Id="2121" Name="Frog" />
-    <Item Id="2122" Name="Mallard Duck" />
-    <Item Id="2123" Name="Duck" />
-    <Item Id="2124" Name="Honey Bathtub" />
-    <Item Id="2125" Name="Steampunk Bathtub" />
-    <Item Id="2126" Name="Living Wood Bathtub" />
-    <Item Id="2127" Name="Shadewood Bathtub" />
-    <Item Id="2128" Name="Bone Bathtub" />
-    <Item Id="2129" Name="Honey Lamp" />
-    <Item Id="2130" Name="Steampunk Lamp" />
-    <Item Id="2131" Name="Living Wood Lamp" />
-    <Item Id="2132" Name="Shadewood Lamp" />
-    <Item Id="2133" Name="Golden Lamp" />
-    <Item Id="2134" Name="Bone Lamp" />
-    <Item Id="2135" Name="Living Wood Bookcase" />
-    <Item Id="2136" Name="Shadewood Bookcase" />
-    <Item Id="2137" Name="Golden Bookcase" />
-    <Item Id="2138" Name="Bone Bookcase" />
-    <Item Id="2139" Name="Living Wood Bed" />
-    <Item Id="2140" Name="Bone Bed" />
-    <Item Id="2141" Name="Living Wood Chandelier" />
-    <Item Id="2142" Name="Shadewood Chandelier" />
-    <Item Id="2143" Name="Golden Chandelier" />
-    <Item Id="2144" Name="Bone Chandelier" />
-    <Item Id="2145" Name="Living Wood Lantern" />
-    <Item Id="2146" Name="Shadewood Lantern" />
-    <Item Id="2147" Name="Golden Lantern" />
-    <Item Id="2148" Name="Bone Lantern" />
-    <Item Id="2149" Name="Living Wood Candelabra" />
-    <Item Id="2150" Name="Shadewood Candelabra" />
-    <Item Id="2151" Name="Golden Candelabra" />
-    <Item Id="2152" Name="Bone Candelabra" />
-    <Item Id="2153" Name="Living Wood Candle" />
-    <Item Id="2154" Name="Shadewood Candle" />
-    <Item Id="2155" Name="Golden Candle" />
-    <Item Id="2156" Name="Black Scorpion" />
-    <Item Id="2157" Name="Scorpion" />
-    <Item Id="2158" Name="Bubble Wallpaper" />
-    <Item Id="2159" Name="Copper Pipe Wallpaper" />
-    <Item Id="2160" Name="Ducky Wallpaper" />
-    <Item Id="2161" Name="Frost Core" />
-    <Item Id="2162" Name="Bunny Cage" />
-    <Item Id="2163" Name="Squirrel Cage" />
-    <Item Id="2164" Name="Mallard Duck Cage" />
-    <Item Id="2165" Name="Duck Cage" />
-    <Item Id="2166" Name="Bird Cage" />
-    <Item Id="2167" Name="Blue Jay Cage" />
-    <Item Id="2168" Name="Cardinal Cage" />
-    <Item Id="2169" Name="Waterfall Wall" />
-    <Item Id="2170" Name="Lavafall Wall" />
-    <Item Id="2171" Name="Crimson Seeds" />
-    <Item Id="2172" Name="Heavy Work Bench" />
-    <Item Id="2173" Name="Copper Plating" />
-    <Item Id="2174" Name="Snail Cage" />
-    <Item Id="2175" Name="Glowing Snail Cage" />
-    <Item Id="2176" Name="Shroomite Digging Claw" Rack="true" />
-    <Item Id="2177" Name="Ammo Box" />
-    <Item Id="2178" Name="Monarch Butterfly Jar" />
-    <Item Id="2179" Name="Purple Emperor Butterfly Jar" />
-    <Item Id="2180" Name="Red Admiral Butterfly Jar" />
-    <Item Id="2181" Name="Ulysses Butterfly Jar" />
-    <Item Id="2182" Name="Sulphur Butterfly Jar" />
-    <Item Id="2183" Name="Tree Nymph Butterfly Jar" />
-    <Item Id="2184" Name="Zebra Swallowtail Butterfly Jar" />
-    <Item Id="2185" Name="Julia Butterfly Jar" />
-    <Item Id="2186" Name="Scorpion Cage" />
-    <Item Id="2187" Name="Black Scorpion Cage" />
-    <Item Id="2188" Name="Venom Staff" Rack="true" />
-    <Item Id="2189" Name="Spectre Mask" Head="156" />
-    <Item Id="2190" Name="Frog Cage" />
-    <Item Id="2191" Name="Mouse Cage" />
-    <Item Id="2192" Name="Bone Welder" />
-    <Item Id="2193" Name="Flesh Cloning Vat" />
-    <Item Id="2194" Name="Glass Kiln" />
-    <Item Id="2195" Name="Lihzahrd Furnace" />
-    <Item Id="2196" Name="Living Loom" />
-    <Item Id="2197" Name="Sky Mill" />
-    <Item Id="2198" Name="Ice Machine" />
-    <Item Id="2199" Name="Beetle Helmet" Head="157" />
-    <Item Id="2200" Name="Beetle Scale Mail" Body="105" />
-    <Item Id="2201" Name="Beetle Shell" Body="106" />
-    <Item Id="2202" Name="Beetle Leggings" Legs="98" />
-    <Item Id="2203" Name="Steampunk Boiler" />
-    <Item Id="2204" Name="Honey Dispenser" />
-    <Item Id="2205" Name="Penguin" />
-    <Item Id="2206" Name="Penguin Cage" />
-    <Item Id="2207" Name="Worm Cage" />
-    <Item Id="2208" Name="Terrarium" />
-    <Item Id="2209" Name="Super Mana Potion" />
-    <Item Id="2210" Name="Ebonwood Fence" />
-    <Item Id="2211" Name="Rich Mahogany Fence" />
-    <Item Id="2212" Name="Pearlwood Fence" />
-    <Item Id="2213" Name="Shadewood Fence" />
-    <Item Id="2214" Name="Brick Layer" />
-    <Item Id="2215" Name="Extendo Grip" />
-    <Item Id="2216" Name="Paint Sprayer" />
-    <Item Id="2217" Name="Portable Cement Mixer" />
-    <Item Id="2218" Name="Beetle Husk" />
-    <Item Id="2219" Name="Celestial Magnet" />
-    <Item Id="2220" Name="Celestial Emblem" />
-    <Item Id="2221" Name="Celestial Cuffs" />
-    <Item Id="2222" Name="Peddler's Hat" Head="158" />
-    <Item Id="2223" Name="Pulse Bow" Rack="true" />
-    <Item Id="2224" Name="Large Dynasty Lantern" />
-    <Item Id="2225" Name="Dynasty Lamp" />
-    <Item Id="2226" Name="Dynasty Lantern" />
-    <Item Id="2227" Name="Large Dynasty Candle" />
-    <Item Id="2228" Name="Dynasty Chair" />
-    <Item Id="2229" Name="Dynasty Work Bench" />
-    <Item Id="2230" Name="Dynasty Chest" />
-    <Item Id="2231" Name="Dynasty Bed" />
-    <Item Id="2232" Name="Dynasty Bathtub" />
-    <Item Id="2233" Name="Dynasty Bookcase" />
-    <Item Id="2234" Name="Dynasty Cup" />
-    <Item Id="2235" Name="Dynasty Bowl" />
-    <Item Id="2236" Name="Dynasty Candle" />
-    <Item Id="2237" Name="Dynasty Clock" />
-    <Item Id="2238" Name="Golden Clock" />
-    <Item Id="2239" Name="Glass Clock" />
-    <Item Id="2240" Name="Honey Clock" />
-    <Item Id="2241" Name="Steampunk Clock" />
-    <Item Id="2242" Name="Fancy Dishes" />
-    <Item Id="2243" Name="Glass Bowl" />
-    <Item Id="2244" Name="Wine Glass" />
-    <Item Id="2245" Name="Living Wood Piano" />
-    <Item Id="2246" Name="Flesh Piano" />
-    <Item Id="2247" Name="Frozen Piano" />
-    <Item Id="2248" Name="Frozen Table" />
-    <Item Id="2249" Name="Honey Chest" />
-    <Item Id="2250" Name="Steampunk Chest" />
-    <Item Id="2251" Name="Honey Work Bench" />
-    <Item Id="2252" Name="Frozen Work Bench" />
-    <Item Id="2253" Name="Steampunk Work Bench" />
-    <Item Id="2254" Name="Glass Piano" />
-    <Item Id="2255" Name="Honey Piano" />
-    <Item Id="2256" Name="Steampunk Piano" />
-    <Item Id="2257" Name="Honey Cup" />
-    <Item Id="2258" Name="Chalice" />
-    <Item Id="2259" Name="Dynasty Table" />
-    <Item Id="2260" Name="Dynasty Wood" />
-    <Item Id="2261" Name="Red Dynasty Shingles" />
-    <Item Id="2262" Name="Blue Dynasty Shingles" />
-    <Item Id="2263" Name="White Dynasty Wall" />
-    <Item Id="2264" Name="Blue Dynasty Wall" />
-    <Item Id="2265" Name="Dynasty Door" />
-    <Item Id="2266" Name="Sake" />
-    <Item Id="2267" Name="Pad Thai" />
-    <Item Id="2268" Name="Pho" />
-    <Item Id="2269" Name="Revolver" Scale="0.85" Rack="true" />
-    <Item Id="2270" Name="Gatligator" Rack="true" />
-    <Item Id="2271" Name="Arcane Rune Wall" />
-    <Item Id="2272" Name="Water Gun" Scale="0.9" />
-    <Item Id="2273" Name="Katana" Rack="true" />
-    <Item Id="2274" Name="Ultrabright Torch" />
-    <Item Id="2275" Name="Magic Hat" Head="159" />
-    <Item Id="2276" Name="Diamond Ring" />
-    <Item Id="2277" Name="Gi" Body="165" />
-    <Item Id="2278" Name="Kimono" Body="166" />
-    <Item Id="2279" Name="Gypsy Robe" Body="167" />
-    <Item Id="2280" Name="Beetle Wings" />
-    <Item Id="2281" Name="Tiger Skin" />
-    <Item Id="2282" Name="Leopard Skin" />
-    <Item Id="2283" Name="Zebra Skin" />
-    <Item Id="2284" Name="Crimson Cloak" />
-    <Item Id="2285" Name="Mysterious Cape" />
-    <Item Id="2286" Name="Red Cape" />
-    <Item Id="2287" Name="Winter Cape" />
-    <Item Id="2288" Name="Frozen Chair" />
-    <Item Id="2289" Name="Wood Fishing Pole" Rack="true" />
-    <Item Id="2290" Name="Bass" />
-    <Item Id="2291" Name="Reinforced Fishing Pole" Rack="true" />
-    <Item Id="2292" Name="Fiberglass Fishing Pole" Rack="true" />
-    <Item Id="2293" Name="Fisher of Souls" Rack="true" />
-    <Item Id="2294" Name="Golden Fishing Rod" Rack="true" />
-    <Item Id="2295" Name="Mechanic's Rod" Rack="true" />
-    <Item Id="2296" Name="Sitting Duck's Fishing Pole" Rack="true" />
-    <Item Id="2297" Name="Trout" />
-    <Item Id="2298" Name="Salmon" />
-    <Item Id="2299" Name="Atlantic Cod" />
-    <Item Id="2300" Name="Tuna" />
-    <Item Id="2301" Name="Red Snapper" />
-    <Item Id="2302" Name="Neon Tetra" />
-    <Item Id="2303" Name="Armored Cavefish" />
-    <Item Id="2304" Name="Damselfish" />
-    <Item Id="2305" Name="Crimson Tigerfish" />
-    <Item Id="2306" Name="Frost Minnow" />
-    <Item Id="2307" Name="Princess Fish" />
-    <Item Id="2308" Name="Golden Carp" />
-    <Item Id="2309" Name="Specular Fish" />
-    <Item Id="2310" Name="Prismite" />
-    <Item Id="2311" Name="Variegated Lardfish" />
-    <Item Id="2312" Name="Flarefin Koi" />
-    <Item Id="2313" Name="Double Cod" />
-    <Item Id="2314" Name="Honeyfin" />
-    <Item Id="2315" Name="Obsidifish" />
-    <Item Id="2316" Name="Shrimp" />
-    <Item Id="2317" Name="Chaos Fish" />
-    <Item Id="2318" Name="Ebonkoi" />
-    <Item Id="2319" Name="Hemopiranha" />
-    <Item Id="2320" Name="Rockfish" Scale="1.05" Rack="true" />
-    <Item Id="2321" Name="Stinkfish" />
-    <Item Id="2322" Name="Mining Potion" />
-    <Item Id="2323" Name="Heartreach Potion" />
-    <Item Id="2324" Name="Calming Potion" />
-    <Item Id="2325" Name="Builder Potion" />
-    <Item Id="2326" Name="Titan Potion" />
-    <Item Id="2327" Name="Flipper Potion" />
-    <Item Id="2328" Name="Summoning Potion" />
-    <Item Id="2329" Name="Dangersense Potion" />
-    <Item Id="2330" Name="Purple Clubberfish" Scale="1.15" Rack="true" />
-    <Item Id="2331" Name="Obsidian Swordfish" Rack="true" />
-    <Item Id="2332" Name="Swordfish" Rack="true" />
-    <Item Id="2333" Name="Iron Fence" />
-    <Item Id="2334" Name="Wooden Crate" />
-    <Item Id="2335" Name="Iron Crate" />
-    <Item Id="2336" Name="Golden Crate" />
-    <Item Id="2337" Name="Old Shoe" />
-    <Item Id="2338" Name="Seaweed" />
-    <Item Id="2339" Name="Tin Can" />
-    <Item Id="2340" Name="Minecart Track" />
-    <Item Id="2341" Name="Reaver Shark" Scale="1.15" Rack="true" />
-    <Item Id="2342" Name="Sawtooth Shark" Rack="true" />
-    <Item Id="2343" Name="Minecart" />
-    <Item Id="2344" Name="Ammo Reservation Potion" />
-    <Item Id="2345" Name="Lifeforce Potion" />
-    <Item Id="2346" Name="Endurance Potion" />
-    <Item Id="2347" Name="Rage Potion" />
-    <Item Id="2348" Name="Inferno Potion" />
-    <Item Id="2349" Name="Wrath Potion" />
-    <Item Id="2350" Name="Recall Potion" />
-    <Item Id="2351" Name="Teleportation Potion" />
-    <Item Id="2352" Name="Love Potion" />
-    <Item Id="2353" Name="Stink Potion" />
-    <Item Id="2354" Name="Fishing Potion" />
-    <Item Id="2355" Name="Sonar Potion" />
-    <Item Id="2356" Name="Crate Potion" />
-    <Item Id="2357" Name="Shiverthorn Seeds" />
-    <Item Id="2358" Name="Shiverthorn" />
-    <Item Id="2359" Name="Warmth Potion" />
-    <Item Id="2360" Name="Fish Hook" />
-    <Item Id="2361" Name="Bee Headgear" Head="160" />
-    <Item Id="2362" Name="Bee Breastplate" Body="168" />
-    <Item Id="2363" Name="Bee Greaves" Legs="103" />
-    <Item Id="2364" Name="Hornet Staff" Rack="true" />
-    <Item Id="2365" Name="Imp Staff" Rack="true" />
-    <Item Id="2366" Name="Queen Spider Staff" Rack="true" />
-    <Item Id="2367" Name="Angler Hat" Head="161" />
-    <Item Id="2368" Name="Angler Vest" Body="169" />
-    <Item Id="2369" Name="Angler Pants" Legs="104" />
-    <Item Id="2370" Name="Spider Mask" Head="162" />
-    <Item Id="2371" Name="Spider Breastplate" Body="170" />
-    <Item Id="2372" Name="Spider Greaves" Legs="105" />
-    <Item Id="2373" Name="High Test Fishing Line" />
-    <Item Id="2374" Name="Angler Earring" />
-    <Item Id="2375" Name="Tackle Box" />
-    <Item Id="2376" Name="Blue Dungeon Piano" />
-    <Item Id="2377" Name="Green Dungeon Piano" />
-    <Item Id="2378" Name="Pink Dungeon Piano" />
-    <Item Id="2379" Name="Golden Piano" />
-    <Item Id="2380" Name="Obsidian Piano" />
-    <Item Id="2381" Name="Bone Piano" />
-    <Item Id="2382" Name="Cactus Piano" />
-    <Item Id="2383" Name="Spooky Piano" />
-    <Item Id="2384" Name="Skyware Piano" />
-    <Item Id="2385" Name="Lihzahrd Piano" />
-    <Item Id="2386" Name="Blue Dungeon Dresser" />
-    <Item Id="2387" Name="Green Dungeon Dresser" />
-    <Item Id="2388" Name="Pink Dungeon Dresser" />
-    <Item Id="2389" Name="Golden Dresser" />
-    <Item Id="2390" Name="Obsidian Dresser" />
-    <Item Id="2391" Name="Bone Dresser" />
-    <Item Id="2392" Name="Cactus Dresser" />
-    <Item Id="2393" Name="Spooky Dresser" />
-    <Item Id="2394" Name="Skyware Dresser" />
-    <Item Id="2395" Name="Honey Dresser" />
-    <Item Id="2396" Name="Lihzahrd Dresser" />
-    <Item Id="2397" Name="Sofa" />
-    <Item Id="2398" Name="Ebonwood Sofa" />
-    <Item Id="2399" Name="Rich Mahogany Sofa" />
-    <Item Id="2400" Name="Pearlwood Sofa" />
-    <Item Id="2401" Name="Shadewood Sofa" />
-    <Item Id="2402" Name="Blue Dungeon Sofa" />
-    <Item Id="2403" Name="Green Dungeon Sofa" />
-    <Item Id="2404" Name="Pink Dungeon Sofa" />
-    <Item Id="2405" Name="Golden Sofa" />
-    <Item Id="2406" Name="Obsidian Sofa" />
-    <Item Id="2407" Name="Bone Sofa" />
-    <Item Id="2408" Name="Cactus Sofa" />
-    <Item Id="2409" Name="Spooky Sofa" />
-    <Item Id="2410" Name="Skyware Sofa" />
-    <Item Id="2411" Name="Honey Sofa" />
-    <Item Id="2412" Name="Steampunk Sofa" />
-    <Item Id="2413" Name="Mushroom Sofa" />
-    <Item Id="2414" Name="Glass Sofa" />
-    <Item Id="2415" Name="Pumpkin Sofa" />
-    <Item Id="2416" Name="Lihzahrd Sofa" />
-    <Item Id="2417" Name="Seashell Hairpin" Head="163" />
-    <Item Id="2418" Name="Mermaid Adornment" Body="171" />
-    <Item Id="2419" Name="Mermaid Tail" Legs="106" />
-    <Item Id="2420" Name="Zephyr Fish" />
-    <Item Id="2421" Name="Fleshcatcher" Rack="true" />
-    <Item Id="2422" Name="Hotline Fishing Hook" Rack="true" />
-    <Item Id="2423" Name="Frog Leg" />
-    <Item Id="2424" Name="Anchor" Rack="true" />
-    <Item Id="2425" Name="Cooked Fish" />
-    <Item Id="2426" Name="Cooked Shrimp" />
-    <Item Id="2427" Name="Sashimi" />
-    <Item Id="2428" Name="Fuzzy Carrot" />
-    <Item Id="2429" Name="Scaly Truffle" />
-    <Item Id="2430" Name="Slimy Saddle" />
-    <Item Id="2431" Name="Bee Wax" />
-    <Item Id="2432" Name="Copper Plating Wall" />
-    <Item Id="2433" Name="Stone Slab Wall" />
-    <Item Id="2434" Name="Sail" />
-    <Item Id="2435" Name="Coralstone Block" />
-    <Item Id="2436" Name="Blue Jellyfish" />
-    <Item Id="2437" Name="Green Jellyfish" />
-    <Item Id="2438" Name="Pink Jellyfish" />
-    <Item Id="2439" Name="Blue Jellyfish Jar" />
-    <Item Id="2440" Name="Green Jellyfish Jar" />
-    <Item Id="2441" Name="Pink Jellyfish Jar" />
-    <Item Id="2442" Name="Life Preserver" />
-    <Item Id="2443" Name="Ship's Wheel" />
-    <Item Id="2444" Name="Compass Rose" />
-    <Item Id="2445" Name="Wall Anchor" />
-    <Item Id="2446" Name="Goldfish Trophy" />
-    <Item Id="2447" Name="Bunnyfish Trophy" />
-    <Item Id="2448" Name="Swordfish Trophy" />
-    <Item Id="2449" Name="Sharkteeth Trophy" />
-    <Item Id="2450" Name="Batfish" />
-    <Item Id="2451" Name="Bumblebee Tuna" />
-    <Item Id="2452" Name="Catfish" />
-    <Item Id="2453" Name="Cloudfish" />
-    <Item Id="2454" Name="Cursedfish" />
-    <Item Id="2455" Name="Dirtfish" />
-    <Item Id="2456" Name="Dynamite Fish" />
-    <Item Id="2457" Name="Eater of Plankton" />
-    <Item Id="2458" Name="Fallen Starfish" />
-    <Item Id="2459" Name="The Fish of Cthulhu" />
-    <Item Id="2460" Name="Fishotron" />
-    <Item Id="2461" Name="Harpyfish" />
-    <Item Id="2462" Name="Hungerfish" />
-    <Item Id="2463" Name="Ichorfish" />
-    <Item Id="2464" Name="Jewelfish" />
-    <Item Id="2465" Name="Mirage Fish" />
-    <Item Id="2466" Name="Mutant Flinxfin" />
-    <Item Id="2467" Name="Pengfish" />
-    <Item Id="2468" Name="Pixiefish" />
-    <Item Id="2469" Name="Spiderfish" />
-    <Item Id="2470" Name="Tundra Trout" />
-    <Item Id="2471" Name="Unicorn Fish" />
-    <Item Id="2472" Name="Guide Voodoo Fish" />
-    <Item Id="2473" Name="Wyverntail" />
-    <Item Id="2474" Name="Zombie Fish" />
-    <Item Id="2475" Name="Amanitia Fungifin" />
-    <Item Id="2476" Name="Angelfish" />
-    <Item Id="2477" Name="Bloody Manowar" />
-    <Item Id="2478" Name="Bonefish" />
-    <Item Id="2479" Name="Bunnyfish" />
-    <Item Id="2480" Name="Cap'n Tunabeard" />
-    <Item Id="2481" Name="Clownfish" />
-    <Item Id="2482" Name="Demonic Hellfish" />
-    <Item Id="2483" Name="Derpfish" />
-    <Item Id="2484" Name="Fishron" />
-    <Item Id="2485" Name="Infected Scabbardfish" />
-    <Item Id="2486" Name="Mudfish" />
-    <Item Id="2487" Name="Slimefish" />
-    <Item Id="2488" Name="Tropical Barracuda" />
-    <Item Id="2489" Name="King Slime Trophy" />
-    <Item Id="2490" Name="Ship in a Bottle" />
-    <Item Id="2491" Name="Hardy Saddle" />
-    <Item Id="2492" Name="Pressure Plate Track" />
-    <Item Id="2493" Name="King Slime Mask" Head="164" />
-    <Item Id="2494" Name="Fin Wings" />
-    <Item Id="2495" Name="Treasure Map" />
-    <Item Id="2496" Name="Seaweed Planter" />
-    <Item Id="2497" Name="Pillagin Me Pixels" />
-    <Item Id="2498" Name="Fish Costume Mask" Head="165" />
-    <Item Id="2499" Name="Fish Costume Shirt" Body="172" />
-    <Item Id="2500" Name="Fish Costume Finskirt" Legs="107" />
-    <Item Id="2501" Name="Ginger Beard" />
-    <Item Id="2502" Name="Honeyed Goggles" />
-    <Item Id="2503" Name="Boreal Wood" />
-    <Item Id="2504" Name="Palm Wood" />
-    <Item Id="2505" Name="Boreal Wood Wall" />
-    <Item Id="2506" Name="Palm Wood Wall" />
-    <Item Id="2507" Name="Boreal Wood Fence" />
-    <Item Id="2508" Name="Palm Wood Fence" />
-    <Item Id="2509" Name="Boreal Wood Helmet" Head="166" />
-    <Item Id="2510" Name="Boreal Wood Breastplate" Body="173" />
-    <Item Id="2511" Name="Boreal Wood Greaves" Legs="108" />
-    <Item Id="2512" Name="Palm Wood Helmet" Head="167" />
-    <Item Id="2513" Name="Palm Wood Breastplate" Body="174" />
-    <Item Id="2514" Name="Palm Wood Greaves" Legs="109" />
-    <Item Id="2515" Name="Palm Wood Bow" Rack="true" />
-    <Item Id="2516" Name="Palm Wood Hammer" Scale="1.1" Rack="true" />
-    <Item Id="2517" Name="Palm Wood Sword" Rack="true" />
-    <Item Id="2518" Name="Palm Wood Platform" />
-    <Item Id="2519" Name="Palm Wood Bathtub" />
-    <Item Id="2520" Name="Palm Wood Bed" />
-    <Item Id="2521" Name="Palm Wood Bench" />
-    <Item Id="2522" Name="Palm Wood Candelabra" />
-    <Item Id="2523" Name="Palm Wood Candle" />
-    <Item Id="2524" Name="Palm Wood Chair" />
-    <Item Id="2525" Name="Palm Wood Chandelier" />
-    <Item Id="2526" Name="Palm Wood Chest" />
-    <Item Id="2527" Name="Palm Wood Sofa" />
-    <Item Id="2528" Name="Palm Wood Door" />
-    <Item Id="2529" Name="Palm Wood Dresser" />
-    <Item Id="2530" Name="Palm Wood Lantern" />
-    <Item Id="2531" Name="Palm Wood Piano" />
-    <Item Id="2532" Name="Palm Wood Table" />
-    <Item Id="2533" Name="Palm Wood Lamp" />
-    <Item Id="2534" Name="Palm Wood Work Bench" />
-    <Item Id="2535" Name="Optic Staff" Rack="true" />
-    <Item Id="2536" Name="Palm Wood Bookcase" />
-    <Item Id="2537" Name="Mushroom Bathtub" />
-    <Item Id="2538" Name="Mushroom Bed" />
-    <Item Id="2539" Name="Mushroom Bench" />
-    <Item Id="2540" Name="Mushroom Bookcase" />
-    <Item Id="2541" Name="Mushroom Candelabra" />
-    <Item Id="2542" Name="Mushroom Candle" />
-    <Item Id="2543" Name="Mushroom Chandelier" />
-    <Item Id="2544" Name="Mushroom Chest" />
-    <Item Id="2545" Name="Mushroom Dresser" />
-    <Item Id="2546" Name="Mushroom Lantern" />
-    <Item Id="2547" Name="Mushroom Lamp" />
-    <Item Id="2548" Name="Mushroom Piano" />
-    <Item Id="2549" Name="Mushroom Platform" />
-    <Item Id="2550" Name="Mushroom Table" />
-    <Item Id="2551" Name="Spider Staff" Rack="true" />
-    <Item Id="2552" Name="Boreal Wood Bathtub" />
-    <Item Id="2553" Name="Boreal Wood Bed" />
-    <Item Id="2554" Name="Boreal Wood Bookcase" />
-    <Item Id="2555" Name="Boreal Wood Candelabra" />
-    <Item Id="2556" Name="Boreal Wood Candle" />
-    <Item Id="2557" Name="Boreal Wood Chair" />
-    <Item Id="2558" Name="Boreal Wood Chandelier" />
-    <Item Id="2559" Name="Boreal Wood Chest" />
-    <Item Id="2560" Name="Boreal Wood Clock" />
-    <Item Id="2561" Name="Boreal Wood Door" />
-    <Item Id="2562" Name="Boreal Wood Dresser" />
-    <Item Id="2563" Name="Boreal Wood Lamp" />
-    <Item Id="2564" Name="Boreal Wood Lantern" />
-    <Item Id="2565" Name="Boreal Wood Piano" />
-    <Item Id="2566" Name="Boreal Wood Platform" />
-    <Item Id="2567" Name="Slime Bathtub" />
-    <Item Id="2568" Name="Slime Bed" />
-    <Item Id="2569" Name="Slime Bookcase" />
-    <Item Id="2570" Name="Slime Candelabra" />
-    <Item Id="2571" Name="Slime Candle" />
-    <Item Id="2572" Name="Slime Chair" />
-    <Item Id="2573" Name="Slime Chandelier" />
-    <Item Id="2574" Name="Slime Chest" />
-    <Item Id="2575" Name="Slime Clock" />
-    <Item Id="2576" Name="Slime Door" />
-    <Item Id="2577" Name="Slime Dresser" />
-    <Item Id="2578" Name="Slime Lamp" />
-    <Item Id="2579" Name="Slime Lantern" />
-    <Item Id="2580" Name="Slime Piano" />
-    <Item Id="2581" Name="Slime Platform" />
-    <Item Id="2582" Name="Slime Sofa" />
-    <Item Id="2583" Name="Slime Table" />
-    <Item Id="2584" Name="Pirate Staff" Rack="true" />
-    <Item Id="2585" Name="Slime Hook" />
-    <Item Id="2586" Name="Sticky Grenade" Rack="true" />
-    <Item Id="2587" Name="Tartar Sauce" />
-    <Item Id="2588" Name="Duke Fishron Mask" Head="168" />
-    <Item Id="2589" Name="Duke Fishron Trophy" />
-    <Item Id="2590" Name="Molotov Cocktail" Rack="true" />
-    <Item Id="2591" Name="Bone Clock" />
-    <Item Id="2592" Name="Cactus Clock" />
-    <Item Id="2593" Name="Ebonwood Clock" />
-    <Item Id="2594" Name="Frozen Clock" />
-    <Item Id="2595" Name="Lihzahrd Clock" />
-    <Item Id="2596" Name="Living Wood Clock" />
-    <Item Id="2597" Name="Rich Mahogany Clock" />
-    <Item Id="2598" Name="Flesh Clock" />
-    <Item Id="2599" Name="Mushroom Clock" />
-    <Item Id="2600" Name="Obsidian Clock" />
-    <Item Id="2601" Name="Palm Wood Clock" />
-    <Item Id="2602" Name="Pearlwood Clock" />
-    <Item Id="2603" Name="Pumpkin Clock" />
-    <Item Id="2604" Name="Shadewood Clock" />
-    <Item Id="2605" Name="Spooky Clock" />
-    <Item Id="2606" Name="Skyware Clock" />
-    <Item Id="2607" Name="Spider Fang" />
-    <Item Id="2608" Name="Falcon Blade" Scale="1.05" Rack="true" />
-    <Item Id="2609" Name="Fishron Wings" />
-    <Item Id="2610" Name="Slime Gun" Scale="0.9" />
-    <Item Id="2611" Name="Flairon" Rack="true" />
-    <Item Id="2612" Name="Green Dungeon Chest" />
-    <Item Id="2613" Name="Pink Dungeon Chest" />
-    <Item Id="2614" Name="Blue Dungeon Chest" />
-    <Item Id="2615" Name="Bone Chest" />
-    <Item Id="2616" Name="Cactus Chest" />
-    <Item Id="2617" Name="Flesh Chest" />
-    <Item Id="2618" Name="Obsidian Chest" />
-    <Item Id="2619" Name="Pumpkin Chest" />
-    <Item Id="2620" Name="Spooky Chest" />
-    <Item Id="2621" Name="Tempest Staff" Rack="true" />
-    <Item Id="2622" Name="Razorblade Typhoon" Scale="0.9" Rack="true" />
-    <Item Id="2623" Name="Bubble Gun" Rack="true" />
-    <Item Id="2624" Name="Tsunami" Rack="true" />
-    <Item Id="2625" Name="Seashell" />
-    <Item Id="2626" Name="Starfish" />
-    <Item Id="2627" Name="Steampunk Platform" />
-    <Item Id="2628" Name="Skyware Platform" />
-    <Item Id="2629" Name="Living Wood Platform" />
-    <Item Id="2630" Name="Honey Platform" />
-    <Item Id="2631" Name="Skyware Work Bench" />
-    <Item Id="2632" Name="Glass Work Bench" />
-    <Item Id="2633" Name="Living Wood Work Bench" />
-    <Item Id="2634" Name="Flesh Sofa" />
-    <Item Id="2635" Name="Frozen Sofa" />
-    <Item Id="2636" Name="Living Wood Sofa" />
-    <Item Id="2637" Name="Pumpkin Dresser" />
-    <Item Id="2638" Name="Steampunk Dresser" />
-    <Item Id="2639" Name="Glass Dresser" />
-    <Item Id="2640" Name="Flesh Dresser" />
-    <Item Id="2641" Name="Pumpkin Lantern" />
-    <Item Id="2642" Name="Obsidian Lantern" />
-    <Item Id="2643" Name="Pumpkin Lamp" />
-    <Item Id="2644" Name="Obsidian Lamp" />
-    <Item Id="2645" Name="Blue Dungeon Lamp" />
-    <Item Id="2646" Name="Green Dungeon Lamp" />
-    <Item Id="2647" Name="Pink Dungeon Lamp" />
-    <Item Id="2648" Name="Honey Candle" />
-    <Item Id="2649" Name="Steampunk Candle" />
-    <Item Id="2650" Name="Spooky Candle" />
-    <Item Id="2651" Name="Obsidian Candle" />
-    <Item Id="2652" Name="Blue Dungeon Chandelier" />
-    <Item Id="2653" Name="Green Dungeon Chandelier" />
-    <Item Id="2654" Name="Pink Dungeon Chandelier" />
-    <Item Id="2655" Name="Steampunk Chandelier" />
-    <Item Id="2656" Name="Pumpkin Chandelier" />
-    <Item Id="2657" Name="Obsidian Chandelier" />
-    <Item Id="2658" Name="Blue Dungeon Bathtub" />
-    <Item Id="2659" Name="Green Dungeon Bathtub" />
-    <Item Id="2660" Name="Pink Dungeon Bathtub" />
-    <Item Id="2661" Name="Pumpkin Bathtub" />
-    <Item Id="2662" Name="Obsidian Bathtub" />
-    <Item Id="2663" Name="Golden Bathtub" />
-    <Item Id="2664" Name="Blue Dungeon Candelabra" />
-    <Item Id="2665" Name="Green Dungeon Candelabra" />
-    <Item Id="2666" Name="Pink Dungeon Candelabra" />
-    <Item Id="2667" Name="Obsidian Candelabra" />
-    <Item Id="2668" Name="Pumpkin Candelabra" />
-    <Item Id="2669" Name="Pumpkin Bed" />
-    <Item Id="2670" Name="Pumpkin Bookcase" />
-    <Item Id="2671" Name="Pumpkin Piano" />
-    <Item Id="2672" Name="Shark Statue" />
-    <Item Id="2673" Name="Truffle Worm" />
-    <Item Id="2674" Name="Apprentice Bait" />
-    <Item Id="2675" Name="Journeyman Bait" />
-    <Item Id="2676" Name="Master Bait" />
-    <Item Id="2677" Name="Amber Gemspark Wall" />
-    <Item Id="2678" Name="Offline Amber Gemspark Wall" />
-    <Item Id="2679" Name="Amethyst Gemspark Wall" />
-    <Item Id="2680" Name="Offline Amethyst Gemspark Wall" />
-    <Item Id="2681" Name="Diamond Gemspark Wall" />
-    <Item Id="2682" Name="Offline Diamond Gemspark Wall" />
-    <Item Id="2683" Name="Emerald Gemspark Wall" />
-    <Item Id="2684" Name="Offline Emerald Gemspark Wall" />
-    <Item Id="2685" Name="Ruby Gemspark Wall" />
-    <Item Id="2686" Name="Offline Ruby Gemspark Wall" />
-    <Item Id="2687" Name="Sapphire Gemspark Wall" />
-    <Item Id="2688" Name="Offline Sapphire Gemspark Wall" />
-    <Item Id="2689" Name="Topaz Gemspark Wall" />
-    <Item Id="2690" Name="Offline Topaz Gemspark Wall" />
-    <Item Id="2691" Name="Tin Plating Wall" />
-    <Item Id="2692" Name="Tin Plating" />
-    <Item Id="2693" Name="Waterfall Block" />
-    <Item Id="2694" Name="Lavafall Block" />
-    <Item Id="2695" Name="Confetti Block" />
-    <Item Id="2696" Name="Confetti Wall" />
-    <Item Id="2697" Name="Midnight Confetti Block" />
-    <Item Id="2698" Name="Midnight Confetti Wall" />
-    <Item Id="2699" Name="Weapon Rack" />
-    <Item Id="2700" Name="Fireworks Box" />
-    <Item Id="2701" Name="Living Fire Block" />
-    <Item Id="2702" Name="'0' Statue" />
-    <Item Id="2703" Name="'1' Statue" />
-    <Item Id="2704" Name="'2' Statue" />
-    <Item Id="2705" Name="'3' Statue" />
-    <Item Id="2706" Name="'4' Statue" />
-    <Item Id="2707" Name="'5' Statue" />
-    <Item Id="2708" Name="'6' Statue" />
-    <Item Id="2709" Name="'7' Statue" />
-    <Item Id="2710" Name="'8' Statue" />
-    <Item Id="2711" Name="'9' Statue" />
-    <Item Id="2712" Name="'A' Statue" />
-    <Item Id="2713" Name="'B' Statue" />
-    <Item Id="2714" Name="'C' Statue" />
-    <Item Id="2715" Name="'D' Statue" />
-    <Item Id="2716" Name="'E' Statue" />
-    <Item Id="2717" Name="'F' Statue" />
-    <Item Id="2718" Name="'G' Statue" />
-    <Item Id="2719" Name="'H' Statue" />
-    <Item Id="2720" Name="'I' Statue" />
-    <Item Id="2721" Name="'J' Statue" />
-    <Item Id="2722" Name="'K' Statue" />
-    <Item Id="2723" Name="'L' Statue" />
-    <Item Id="2724" Name="'M' Statue" />
-    <Item Id="2725" Name="'N' Statue" />
-    <Item Id="2726" Name="'O' Statue" />
-    <Item Id="2727" Name="'P' Statue" />
-    <Item Id="2728" Name="'Q' Statue" />
-    <Item Id="2729" Name="'R' Statue" />
-    <Item Id="2730" Name="'S' Statue" />
-    <Item Id="2731" Name="'T' Statue" />
-    <Item Id="2732" Name="'U' Statue" />
-    <Item Id="2733" Name="'V' Statue" />
-    <Item Id="2734" Name="'W' Statue" />
-    <Item Id="2735" Name="'X' Statue" />
-    <Item Id="2736" Name="'Y' Statue" />
-    <Item Id="2737" Name="'Z' Statue" />
-    <Item Id="2738" Name="Firework Fountain" />
-    <Item Id="2739" Name="Booster Track" />
-    <Item Id="2740" Name="Grasshopper" />
-    <Item Id="2741" Name="Grasshopper Cage" />
-    <Item Id="2742" Name="Music Box (Underground Crimson)" />
-    <Item Id="2743" Name="Cactus Table" />
-    <Item Id="2744" Name="Cactus Platform" />
-    <Item Id="2745" Name="Boreal Wood Sword" Rack="true" />
-    <Item Id="2746" Name="Boreal Wood Hammer" Scale="1.1" Rack="true" />
-    <Item Id="2747" Name="Boreal Wood Bow" Rack="true" />
-    <Item Id="2748" Name="Glass Chest" />
-    <Item Id="2749" Name="Xeno Staff" Rack="true" />
-    <Item Id="2750" Name="Meteor Staff" Rack="true" />
-    <Item Id="2751" Name="Living Cursed Fire Block" />
-    <Item Id="2752" Name="Living Demon Fire Block" />
-    <Item Id="2753" Name="Living Frost Fire Block" />
-    <Item Id="2754" Name="Living Ichor Block" />
-    <Item Id="2755" Name="Living Ultrabright Fire Block" />
-    <Item Id="2756" Name="Gender Change Potion" />
-    <Item Id="2757" Name="Vortex Helmet" Head="169" />
-    <Item Id="2758" Name="Vortex Breastplate" Body="175" />
-    <Item Id="2759" Name="Vortex Leggings" Legs="110" />
-    <Item Id="2760" Name="Nebula Helmet" Head="170" />
-    <Item Id="2761" Name="Nebula Breastplate" Body="176" />
-    <Item Id="2762" Name="Nebula Leggings" Legs="111" />
-    <Item Id="2763" Name="Solar Flare Helmet" Head="171" />
-    <Item Id="2764" Name="Solar Flare Breastplate" Body="177" />
-    <Item Id="2765" Name="Solar Flare Leggings" Legs="112" />
-    <Item Id="2766" Name="Solar Tablet Fragment" />
-    <Item Id="2767" Name="Solar Tablet" />
-    <Item Id="2768" Name="Drill Containment Unit" />
-    <Item Id="2769" Name="Cosmic Car Key" />
-    <Item Id="2770" Name="Mothron Wings" />
-    <Item Id="2771" Name="Brain Scrambler" />
-    <Item Id="2772" Name="Vortex Axe" Scale="1.05" Rack="true" />
-    <Item Id="2773" Name="Vortex Chainsaw" Rack="true" />
-    <Item Id="2774" Name="Vortex Drill" Rack="true" />
-    <Item Id="2775" Name="Vortex Hammer" Scale="1.1" Rack="true" />
-    <Item Id="2776" Name="Vortex Pickaxe" Rack="true" />
-    <Item Id="2777" Name="Nebula Axe" Rack="true" />
-    <Item Id="2778" Name="Nebula Chainsaw" Rack="true" />
-    <Item Id="2779" Name="Nebula Drill" Rack="true" />
-    <Item Id="2780" Name="Nebula Hammer" Rack="true" />
-    <Item Id="2781" Name="Nebula Pickaxe" Rack="true" />
-    <Item Id="2782" Name="Solar Flare Axe" Rack="true" />
-    <Item Id="2783" Name="Solar Flare Chainsaw" Rack="true" />
-    <Item Id="2784" Name="Solar Flare Drill" Rack="true" />
-    <Item Id="2785" Name="Solar Flare Hammer" Rack="true" />
-    <Item Id="2786" Name="Solar Flare Pickaxe" Rack="true" />
-    <Item Id="2787" Name="Honeyfall Block" />
-    <Item Id="2788" Name="Honeyfall Wall" />
-    <Item Id="2789" Name="Chlorophyte Brick Wall" />
-    <Item Id="2790" Name="Crimtane Brick Wall" />
-    <Item Id="2791" Name="Shroomite Plating Wall" />
-    <Item Id="2792" Name="Chlorophyte Brick" />
-    <Item Id="2793" Name="Crimtane Brick" />
-    <Item Id="2794" Name="Shroomite Plating" />
-    <Item Id="2795" Name="Laser Machinegun" Rack="true" />
-    <Item Id="2796" Name="Electrosphere Launcher" Rack="true" />
-    <Item Id="2797" Name="Xenopopper" Rack="true" />
-    <Item Id="2798" Name="Laser Drill" Rack="true" />
-    <Item Id="2799" Name="Mechanical Ruler" />
-    <Item Id="2800" Name="Anti-Gravity Hook" />
-    <Item Id="2801" Name="Moon Mask" Head="172" />
-    <Item Id="2802" Name="Sun Mask" Head="173" />
-    <Item Id="2803" Name="Martian Costume Mask" Head="174" />
-    <Item Id="2804" Name="Martian Costume Shirt" Body="178" />
-    <Item Id="2805" Name="Martian Costume Pants" Legs="113" />
-    <Item Id="2806" Name="Martian Uniform Helmet" Head="175" />
-    <Item Id="2807" Name="Martian Uniform Torso" Body="179" />
-    <Item Id="2808" Name="Martian Uniform Pants" Legs="114" />
-    <Item Id="2809" Name="Martian Astro Clock" />
-    <Item Id="2810" Name="Martian Bathtub" />
-    <Item Id="2811" Name="Martian Bed" />
-    <Item Id="2812" Name="Martian Hover Chair" />
-    <Item Id="2813" Name="Martian Chandelier" />
-    <Item Id="2814" Name="Martian Chest" />
-    <Item Id="2815" Name="Martian Door" />
-    <Item Id="2816" Name="Martian Dresser" />
-    <Item Id="2817" Name="Martian Holobookcase" />
-    <Item Id="2818" Name="Martian Hover Candle" />
-    <Item Id="2819" Name="Martian Lamppost" />
-    <Item Id="2820" Name="Martian Lantern" />
-    <Item Id="2821" Name="Martian Piano" />
-    <Item Id="2822" Name="Martian Platform" />
-    <Item Id="2823" Name="Martian Sofa" />
-    <Item Id="2824" Name="Martian Table" />
-    <Item Id="2825" Name="Martian Table Lamp" />
-    <Item Id="2826" Name="Martian Work Bench" />
-    <Item Id="2827" Name="Wooden Sink" />
-    <Item Id="2828" Name="Ebonwood Sink" />
-    <Item Id="2829" Name="Rich Mahogany Sink" />
-    <Item Id="2830" Name="Pearlwood Sink" />
-    <Item Id="2831" Name="Bone Sink" />
-    <Item Id="2832" Name="Flesh Sink" />
-    <Item Id="2833" Name="Living Wood Sink" />
-    <Item Id="2834" Name="Skyware Sink" />
-    <Item Id="2835" Name="Shadewood Sink" />
-    <Item Id="2836" Name="Lihzahrd Sink" />
-    <Item Id="2837" Name="Blue Dungeon Sink" />
-    <Item Id="2838" Name="Green Dungeon Sink" />
-    <Item Id="2839" Name="Pink Dungeon Sink" />
-    <Item Id="2840" Name="Obsidian Sink" />
-    <Item Id="2841" Name="Metal Sink" />
-    <Item Id="2842" Name="Glass Sink" />
-    <Item Id="2843" Name="Golden Sink" />
-    <Item Id="2844" Name="Honey Sink" />
-    <Item Id="2845" Name="Steampunk Sink" />
-    <Item Id="2846" Name="Pumpkin Sink" />
-    <Item Id="2847" Name="Spooky Sink" />
-    <Item Id="2848" Name="Frozen Sink" />
-    <Item Id="2849" Name="Dynasty Sink" />
-    <Item Id="2850" Name="Palm Wood Sink" />
-    <Item Id="2851" Name="Mushroom Sink" />
-    <Item Id="2852" Name="Boreal Wood Sink" />
-    <Item Id="2853" Name="Slime Sink" />
-    <Item Id="2854" Name="Cactus Sink" />
-    <Item Id="2855" Name="Martian Sink" />
-    <Item Id="2856" Name="Solar Cultist Hood" Head="176" />
-    <Item Id="2857" Name="Lunar Cultist Hood" Head="177" />
-    <Item Id="2858" Name="Solar Cultist Robe" Body="180" />
-    <Item Id="2859" Name="Lunar Cultist Robe" Body="181" />
-    <Item Id="2860" Name="Martian Conduit Plating" />
-    <Item Id="2861" Name="Martian Conduit Wall" />
-    <Item Id="2862" Name="HiTek Sunglasses" Head="178" />
-    <Item Id="2863" Name="Martian Hair Dye" />
-    <Item Id="2864" Name="Martian Dye" />
-    <Item Id="2865" Name="Castle Marsberg" />
-    <Item Id="2866" Name="Martia Lisa" />
-    <Item Id="2867" Name="The Truth Is Up There" />
-    <Item Id="2868" Name="Smoke Block" />
-    <Item Id="2869" Name="Living Flame Dye" />
-    <Item Id="2870" Name="Living Rainbow Dye" />
-    <Item Id="2871" Name="Shadow Dye" />
-    <Item Id="2872" Name="Negative Dye" />
-    <Item Id="2873" Name="Living Ocean Dye" />
-    <Item Id="2874" Name="Brown Dye" />
-    <Item Id="2875" Name="Brown and Black Dye" />
-    <Item Id="2876" Name="Bright Brown Dye" />
-    <Item Id="2877" Name="Brown and Silver Dye" />
-    <Item Id="2878" Name="Wisp Dye" />
-    <Item Id="2879" Name="Pixie Dye" />
-    <Item Id="2880" Name="Influx Waver" Scale="1.05" Rack="true" />
+    <Item Id="415" Name="钴砖" />
+    <Item Id="416" Name="秘银砖" />
+    <Item Id="417" Name="珍珠石砖墙" />
+    <Item Id="418" Name="荧光砖墙" />
+    <Item Id="419" Name="泥石砖墙" />
+    <Item Id="420" Name="钴砖墙" />
+    <Item Id="421" Name="秘银砖墙" />
+    <Item Id="422" Name="圣水" Rack="true" />
+    <Item Id="423" Name="邪水" Rack="true" />
+    <Item Id="424" Name="泥沙块" />
+    <Item Id="425" Name="仙灵铃铛" Rack="true" />
+    <Item Id="426" Name="毁灭刃" Scale="1.05" Rack="true" />
+    <Item Id="427" Name="蓝火把" />
+    <Item Id="428" Name="红火把" />
+    <Item Id="429" Name="绿火把" />
+    <Item Id="430" Name="紫火把" />
+    <Item Id="431" Name="白火把" />
+    <Item Id="432" Name="黄火把" />
+    <Item Id="433" Name="恶魔火把" />
+    <Item Id="434" Name="发条式突击步枪" Rack="true" />
+    <Item Id="435" Name="钴连弩" Rack="true" />
+    <Item Id="436" Name="秘银连弩" Rack="true" />
+    <Item Id="437" Name="双钩" />
+    <Item Id="438" Name="星星雕像" />
+    <Item Id="439" Name="宝剑雕像" />
+    <Item Id="440" Name="史莱姆雕像" />
+    <Item Id="441" Name="哥布林雕像" />
+    <Item Id="442" Name="护盾雕像" />
+    <Item Id="443" Name="蝙蝠雕像" />
+    <Item Id="444" Name="金鱼雕像" />
+    <Item Id="445" Name="兔兔雕像" />
+    <Item Id="446" Name="骷髅雕像" />
+    <Item Id="447" Name="死神雕像" />
+    <Item Id="448" Name="女人雕像" />
+    <Item Id="449" Name="小鬼雕像" />
+    <Item Id="450" Name="石像鬼雕像" />
+    <Item Id="451" Name="幽冥雕像" />
+    <Item Id="452" Name="黄蜂雕像" />
+    <Item Id="453" Name="炸弹雕像" />
+    <Item Id="454" Name="螃蟹雕像" />
+    <Item Id="455" Name="战锤雕像" />
+    <Item Id="456" Name="药水雕像" />
+    <Item Id="457" Name="长矛雕像" />
+    <Item Id="458" Name="十字架雕像" />
+    <Item Id="459" Name="水母雕像" />
+    <Item Id="460" Name="弓雕像" />
+    <Item Id="461" Name="回旋镖雕像" />
+    <Item Id="462" Name="靴子雕像" />
+    <Item Id="463" Name="宝箱雕像" />
+    <Item Id="464" Name="小鸟雕像" />
+    <Item Id="465" Name="战斧雕像" />
+    <Item Id="466" Name="腐化雕像" />
+    <Item Id="467" Name="树木雕像" />
+    <Item Id="468" Name="砧雕像" />
+    <Item Id="469" Name="镐雕像" />
+    <Item Id="470" Name="蘑菇雕像" />
+    <Item Id="471" Name="魔眼雕像" />
+    <Item Id="472" Name="石柱雕像" />
+    <Item Id="473" Name="心形雕像" />
+    <Item Id="474" Name="陶罐雕像" />
+    <Item Id="475" Name="向日葵雕像" />
+    <Item Id="476" Name="国王雕像" />
+    <Item Id="477" Name="女王雕像" />
+    <Item Id="478" Name="食人鱼雕像" />
+    <Item Id="479" Name="板条墙" />
+    <Item Id="480" Name="木梁" />
+    <Item Id="481" Name="精金连弩" Rack="true" />
+    <Item Id="482" Name="精金剑" Scale="1.2" Rack="true" />
+    <Item Id="483" Name="钴剑" Scale="1.1" Rack="true" />
+    <Item Id="484" Name="秘银剑" Scale="1.15" Rack="true" />
+    <Item Id="485" Name="月光护身符" />
+    <Item Id="486" Name="标尺" />
+    <Item Id="487" Name="水晶球" />
+    <Item Id="488" Name="迪斯科球" />
+    <Item Id="489" Name="巫士徽章" />
+    <Item Id="490" Name="战士徽章" />
+    <Item Id="491" Name="游侠徽章" />
+    <Item Id="492" Name="恶魔之翼" />
+    <Item Id="493" Name="天使之翼" />
+    <Item Id="494" Name="魔法竖琴" Rack="true" />
+    <Item Id="495" Name="彩虹魔杖" Rack="true" />
+    <Item Id="496" Name="冰雪魔杖" Rack="true" />
+    <Item Id="497" Name="海神贝壳" />
+    <Item Id="498" Name="人体模型" />
+    <Item Id="499" Name="强效治疗药水" />
+    <Item Id="500" Name="强效魔力药水" />
+    <Item Id="501" Name="妖精尘" />
+    <Item Id="502" Name="水晶碎块" />
+    <Item Id="503" Name="小丑帽" Head="40" />
+    <Item Id="504" Name="小丑衣" Body="23" />
+    <Item Id="505" Name="小丑裤" Legs="22" />
+    <Item Id="506" Name="火焰喷射器" Rack="true" />
+    <Item Id="507" Name="铃铛" />
+    <Item Id="508" Name="竖琴" />
+    <Item Id="509" Name="红扳手" />
+    <Item Id="510" Name="钢丝钳" />
+    <Item Id="511" Name="通电石块" />
+    <Item Id="512" Name="未通电石块" />
+    <Item Id="513" Name="控制杆" />
+    <Item Id="514" Name="激光步枪" Rack="true" />
+    <Item Id="515" Name="水晶子弹" Rack="true" />
+    <Item Id="516" Name="圣箭" Rack="true" />
+    <Item Id="517" Name="魔法飞刀" Rack="true" />
+    <Item Id="518" Name="水晶风暴" Scale="0.9" Rack="true" />
+    <Item Id="519" Name="诅咒焰" Scale="0.9" Rack="true" />
+    <Item Id="520" Name="光明之魂" />
+    <Item Id="521" Name="暗影之魂" />
+    <Item Id="522" Name="诅咒焰" />
+    <Item Id="523" Name="诅咒火把" />
+    <Item Id="524" Name="精金熔炉" />
+    <Item Id="525" Name="秘银砧" />
+    <Item Id="526" Name="独角兽角" />
+    <Item Id="527" Name="暗黑碎块" />
+    <Item Id="528" Name="光明碎块" />
+    <Item Id="529" Name="红压力板" />
+    <Item Id="530" Name="电线" />
+    <Item Id="531" Name="魔法书" />
+    <Item Id="532" Name="星星斗篷" />
+    <Item Id="533" Name="巨兽鲨" Rack="true" />
+    <Item Id="534" Name="霰弹枪" Rack="true" />
+    <Item Id="535" Name="点金石" />
+    <Item Id="536" Name="泰坦手套" />
+    <Item Id="537" Name="钴剃刀" Scale="1.1" Rack="true" />
+    <Item Id="538" Name="开关" />
+    <Item Id="539" Name="飞镖机关" />
+    <Item Id="540" Name="巨石" />
+    <Item Id="541" Name="绿压力板" />
+    <Item Id="542" Name="灰压力板" />
+    <Item Id="543" Name="棕压力板" />
+    <Item Id="544" Name="机械魔眼" />
+    <Item Id="545" Name="诅咒箭" Rack="true" />
+    <Item Id="546" Name="诅咒弹" Rack="true" />
+    <Item Id="547" Name="恐惧之魂" />
+    <Item Id="548" Name="力量之魂" />
+    <Item Id="549" Name="视域之魂" />
+    <Item Id="550" Name="永恒之枪" Scale="1.1" Rack="true" />
+    <Item Id="551" Name="神圣板甲" Body="24" />
+    <Item Id="552" Name="神圣护胫" Legs="23" />
+    <Item Id="553" Name="神圣头盔" Head="41" />
+    <Item Id="554" Name="十字项链" />
+    <Item Id="555" Name="魔力花" />
+    <Item Id="556" Name="机械蠕虫" />
+    <Item Id="557" Name="机械骷髅头" />
+    <Item Id="558" Name="神圣头饰" Head="42" />
+    <Item Id="559" Name="神圣面具" Head="43" />
+    <Item Id="560" Name="史莱姆王冠" />
+    <Item Id="561" Name="光辉飞盘" Rack="true" />
+    <Item Id="562" Name="八音盒（人间日）" />
+    <Item Id="563" Name="八音盒（恐惧）" />
+    <Item Id="564" Name="八音盒（暗夜）" />
+    <Item Id="565" Name="八音盒（标题）" />
+    <Item Id="566" Name="八音盒（地下）" />
+    <Item Id="567" Name="八音盒(Boss 1)" />
+    <Item Id="568" Name="八音盒（丛林）" />
+    <Item Id="569" Name="八音盒（腐化之地）" />
+    <Item Id="570" Name="八音盒（地下腐化之地）" />
+    <Item Id="571" Name="八音盒（神圣之地）" />
+    <Item Id="572" Name="八音盒(Boss 2(" />
+    <Item Id="573" Name="八音盒（地下神圣之地）" />
+    <Item Id="574" Name="八音盒(Boss 3)" />
+    <Item Id="575" Name="飞翔之魂" />
+    <Item Id="576" Name="八音盒" />
+    <Item Id="577" Name="魔矿砖" />
+    <Item Id="578" Name="神圣连弩" Rack="true" />
+    <Item Id="579" Name="斧钻" Rack="true" />
+    <Item Id="580" Name="炸药" />
+    <Item Id="581" Name="入水泵" />
+    <Item Id="582" Name="出水泵" />
+    <Item Id="583" Name="1秒计时器" />
+    <Item Id="584" Name="3秒计时器" />
+    <Item Id="585" Name="5秒计时器" />
+    <Item Id="586" Name="糖棒块" />
+    <Item Id="587" Name="糖棒墙" />
+    <Item Id="588" Name="圣诞帽" Head="44" />
+    <Item Id="589" Name="圣诞衣" Body="25" />
+    <Item Id="590" Name="圣诞裤" Legs="24" />
+    <Item Id="591" Name="绿糖棒块" />
+    <Item Id="592" Name="绿糖棒墙" />
+    <Item Id="593" Name="雪块" />
+    <Item Id="594" Name="雪砖" />
+    <Item Id="595" Name="雪砖墙" />
+    <Item Id="596" Name="蓝灯" />
+    <Item Id="597" Name="红灯" />
+    <Item Id="598" Name="绿灯" />
+    <Item Id="599" Name="蓝礼物" />
+    <Item Id="600" Name="绿礼物" />
+    <Item Id="601" Name="黄礼物" />
+    <Item Id="602" Name="水晶雪球" />
+    <Item Id="603" Name="胡萝卜" />
+    <Item Id="604" Name="精金梁" />
+    <Item Id="605" Name="精金梁墙" />
+    <Item Id="606" Name="魔矿砖墙" />
+    <Item Id="607" Name="沙岩砖" />
+    <Item Id="608" Name="沙岩砖墙" />
+    <Item Id="609" Name="黑檀石砖" />
+    <Item Id="610" Name="黑檀石砖墙" />
+    <Item Id="611" Name="红泥灰" />
+    <Item Id="612" Name="黄泥灰" />
+    <Item Id="613" Name="绿泥灰" />
+    <Item Id="614" Name="灰泥灰" />
+    <Item Id="615" Name="红泥灰墙" />
+    <Item Id="616" Name="黄泥灰墙" />
+    <Item Id="617" Name="绿泥灰墙" />
+    <Item Id="618" Name="灰泥灰墙" />
+    <Item Id="619" Name="乌木" />
+    <Item Id="620" Name="红木" />
+    <Item Id="621" Name="珍珠木" />
+    <Item Id="622" Name="乌木墙" />
+    <Item Id="623" Name="红木墙" />
+    <Item Id="624" Name="珍珠木墙" />
+    <Item Id="625" Name="乌木箱" />
+    <Item Id="626" Name="红木箱" />
+    <Item Id="627" Name="珍珠木箱" />
+    <Item Id="628" Name="乌木椅" />
+    <Item Id="629" Name="红木椅" />
+    <Item Id="630" Name="珍珠木椅" />
+    <Item Id="631" Name="乌木平台" />
+    <Item Id="632" Name="红木平台" />
+    <Item Id="633" Name="珍珠木平台" />
+    <Item Id="634" Name="骨头平台" />
+    <Item Id="635" Name="乌木工作台" />
+    <Item Id="636" Name="红木工作台" />
+    <Item Id="637" Name="珍珠木工作台" />
+    <Item Id="638" Name="乌木桌" />
+    <Item Id="639" Name="红木桌" />
+    <Item Id="640" Name="珍珠木桌" />
+    <Item Id="641" Name="乌木钢琴" />
+    <Item Id="642" Name="红木钢琴" />
+    <Item Id="643" Name="珍珠木钢琴" />
+    <Item Id="644" Name="乌木床" />
+    <Item Id="645" Name="红木床" />
+    <Item Id="646" Name="珍珠木床" />
+    <Item Id="647" Name="乌木梳妆台" />
+    <Item Id="648" Name="红木梳妆台" />
+    <Item Id="649" Name="珍珠木梳妆台" />
+    <Item Id="650" Name="乌木门" />
+    <Item Id="651" Name="红木门" />
+    <Item Id="652" Name="珍珠木门" />
+    <Item Id="653" Name="乌木剑" Rack="true" />
+    <Item Id="654" Name="乌木锤" Scale="1.2" Rack="true" />
+    <Item Id="655" Name="乌木弓" Rack="true" />
+    <Item Id="656" Name="红木剑" Rack="true" />
+    <Item Id="657" Name="红木锤" Scale="1.1" Rack="true" />
+    <Item Id="658" Name="红木弓" Rack="true" />
+    <Item Id="659" Name="珍珠木剑" Rack="true" />
+    <Item Id="660" Name="珍珠木锤" Scale="1.25" Rack="true" />
+    <Item Id="661" Name="珍珠木弓" Rack="true" />
+    <Item Id="662" Name="彩虹砖" />
+    <Item Id="663" Name="彩虹砖墙" />
+    <Item Id="664" Name="冰雪块" />
+    <Item Id="665" Name="Red的翅膀" />
+    <Item Id="666" Name="Red的头盔" Head="45" />
+    <Item Id="667" Name="Red的胸甲" Body="26" />
+    <Item Id="668" Name="Red的护腿" Legs="25" />
+    <Item Id="669" Name="鱼" />
+    <Item Id="670" Name="冰雪回旋镖" Rack="true" />
+    <Item Id="671" Name="钥匙剑" Scale="1.2" Rack="true" />
+    <Item Id="672" Name="短弯刀" Scale="1.1" Rack="true" />
+    <Item Id="673" Name="针叶木工作台" />
+    <Item Id="674" Name="原版断钢剑" Scale="1.05" Rack="true" />
+    <Item Id="675" Name="原版永夜刃" Scale="1.15" Rack="true" />
+    <Item Id="676" Name="霜印剑" Scale="1.15" Rack="true" />
+    <Item Id="677" Name="针叶木桌" />
+    <Item Id="678" Name="红药水" />
+    <Item Id="679" Name="战术霰弹枪" Rack="true" />
+    <Item Id="680" Name="常春藤箱" />
+    <Item Id="681" Name="冰雪箱" />
+    <Item Id="682" Name="骸骨弓" Scale="1.1" Rack="true" />
+    <Item Id="683" Name="邪恶三叉戟" Rack="true" />
+    <Item Id="684" Name="寒霜头盔" Head="46" />
+    <Item Id="685" Name="寒霜胸甲" Body="27" />
+    <Item Id="686" Name="寒霜护腿" Legs="26" />
+    <Item Id="687" Name="锡头盔" Head="47" />
+    <Item Id="688" Name="锡链甲" Body="28" />
+    <Item Id="689" Name="锡护胫" Legs="27" />
+    <Item Id="690" Name="铅头盔" Head="48" />
+    <Item Id="691" Name="铅链甲" Body="29" />
+    <Item Id="692" Name="铅护胫" Legs="28" />
+    <Item Id="693" Name="钨头盔" Head="49" />
+    <Item Id="694" Name="钨链甲" Body="30" />
+    <Item Id="695" Name="钨护胫" Legs="29" />
+    <Item Id="696" Name="铂金头盔" Head="50" />
+    <Item Id="697" Name="铂金链甲" Body="31" />
+    <Item Id="698" Name="铂金护胫" Legs="30" />
+    <Item Id="699" Name="锡矿" />
+    <Item Id="700" Name="铅矿" />
+    <Item Id="701" Name="钨矿" />
+    <Item Id="702" Name="铂金矿" />
+    <Item Id="703" Name="锡锭" />
+    <Item Id="704" Name="铅锭" />
+    <Item Id="705" Name="钨锭" />
+    <Item Id="706" Name="铂金锭" />
+    <Item Id="707" Name="锡表" />
+    <Item Id="708" Name="钨表" />
+    <Item Id="709" Name="铂金表" />
+    <Item Id="710" Name="锡吊灯" />
+    <Item Id="711" Name="钨吊灯" />
+    <Item Id="712" Name="铂金吊灯" />
+    <Item Id="713" Name="铂金蜡烛" />
+    <Item Id="714" Name="铂金烛台" />
+    <Item Id="715" Name="铂金冠" Head="51" />
+    <Item Id="716" Name="铅砧" />
+    <Item Id="717" Name="锡砖" />
+    <Item Id="718" Name="钨砖" />
+    <Item Id="719" Name="铂金砖" />
+    <Item Id="720" Name="锡砖墙" />
+    <Item Id="721" Name="钨砖墙" />
+    <Item Id="722" Name="铂金砖墙" />
+    <Item Id="723" Name="光束剑" Rack="true" />
+    <Item Id="724" Name="冰雪刃" Rack="true" />
+    <Item Id="725" Name="冰雪弓" Rack="true" />
+    <Item Id="726" Name="寒霜法杖" Rack="true" />
+    <Item Id="727" Name="木头盔" Head="52" />
+    <Item Id="728" Name="木胸甲" Body="32" />
+    <Item Id="729" Name="木护胫" Legs="31" />
+    <Item Id="730" Name="乌木头盔" Head="53" />
+    <Item Id="731" Name="乌木胸甲" Body="33" />
+    <Item Id="732" Name="乌木护胫" Legs="32" />
+    <Item Id="733" Name="红木头盔" Head="54" />
+    <Item Id="734" Name="红木胸甲" Body="34" />
+    <Item Id="735" Name="红木护胫" Legs="33" />
+    <Item Id="736" Name="珍珠木头盔" Head="55" />
+    <Item Id="737" Name="珍珠木胸甲" Body="35" />
+    <Item Id="738" Name="珍珠木护胫" Legs="34" />
+    <Item Id="739" Name="紫晶法杖" Rack="true" />
+    <Item Id="740" Name="黄玉法杖" Rack="true" />
+    <Item Id="741" Name="蓝玉法杖" Rack="true" />
+    <Item Id="742" Name="翡翠法杖" Rack="true" />
+    <Item Id="743" Name="红玉法杖" Rack="true" />
+    <Item Id="744" Name="钻石法杖" Rack="true" />
+    <Item Id="745" Name="草墙" />
+    <Item Id="746" Name="丛林墙" />
+    <Item Id="747" Name="花墙" />
+    <Item Id="748" Name="喷气背包" />
+    <Item Id="749" Name="蝴蝶之翼" />
+    <Item Id="750" Name="仙人掌墙" />
+    <Item Id="751" Name="云" />
+    <Item Id="752" Name="云墙" />
+    <Item Id="753" Name="海草" />
+    <Item Id="754" Name="符文帽" Head="56" />
+    <Item Id="755" Name="符文长袍" Body="36" />
+    <Item Id="756" Name="蘑菇长矛" Rack="true" />
+    <Item Id="757" Name="泰拉刃" Scale="1.1" Rack="true" />
+    <Item Id="758" Name="手榴弹发射器" Rack="true" />
+    <Item Id="759" Name="火箭发射器" Rack="true" />
+    <Item Id="760" Name="感应雷发射器" Rack="true" />
+    <Item Id="761" Name="仙灵之翼" />
+    <Item Id="762" Name="史莱姆块" />
+    <Item Id="763" Name="血肉块" />
+    <Item Id="764" Name="蘑菇墙" />
+    <Item Id="765" Name="雨云" />
+    <Item Id="766" Name="骨块" />
+    <Item Id="767" Name="冰冻史莱姆块" />
+    <Item Id="768" Name="骨块墙" />
+    <Item Id="769" Name="史莱姆块墙" />
+    <Item Id="770" Name="血肉块墙" />
+    <Item Id="771" Name="初级火箭" Rack="true" />
+    <Item Id="772" Name="二级火箭" Rack="true" />
+    <Item Id="773" Name="三级火箭" Rack="true" />
+    <Item Id="774" Name="四级火箭" Rack="true" />
+    <Item Id="775" Name="沥青块" />
+    <Item Id="776" Name="钴镐" Scale="1.15" Rack="true" />
+    <Item Id="777" Name="秘银镐" Scale="1.15" Rack="true" />
+    <Item Id="778" Name="精金镐" Scale="1.15" Rack="true" />
+    <Item Id="779" Name="环境改造枪" />
+    <Item Id="780" Name="绿溶液" />
+    <Item Id="781" Name="蓝溶液" />
+    <Item Id="782" Name="紫溶液" />
+    <Item Id="783" Name="深蓝溶液" />
+    <Item Id="784" Name="红溶液" />
+    <Item Id="785" Name="鸟妖之翼" />
+    <Item Id="786" Name="骨之翼" />
+    <Item Id="787" Name="蘑菇锤" Scale="1.1" Rack="true" />
+    <Item Id="788" Name="爆裂藤蔓" Rack="true" />
+    <Item Id="789" Name="十字章旗" />
+    <Item Id="790" Name="蛇旗" />
+    <Item Id="791" Name="欧米茄旗" />
+    <Item Id="792" Name="猩红头盔" Head="57" />
+    <Item Id="793" Name="猩红鳞甲" Body="37" />
+    <Item Id="794" Name="猩红护胫" Legs="35" />
+    <Item Id="795" Name="血腥屠刀" Scale="1.1" Rack="true" />
+    <Item Id="796" Name="肌腱弓" Rack="true" />
+    <Item Id="797" Name="血肉锤" Scale="1.2" Rack="true" />
+    <Item Id="798" Name="死亡使者镐" Scale="1.15" Rack="true" />
+    <Item Id="799" Name="嗜血狂斧" Scale="1.2" Rack="true" />
+    <Item Id="800" Name="夺命枪" Scale="0.9" Rack="true" />
+    <Item Id="801" Name="血肉之球" Scale="1.1" Rack="true" />
+    <Item Id="802" Name="腐叉" Scale="1.1" Rack="true" />
+    <Item Id="803" Name="爱斯基摩兜帽" Head="58" />
+    <Item Id="804" Name="爱斯基摩大衣" Body="38" />
+    <Item Id="805" Name="爱斯基摩裤" Legs="36" />
+    <Item Id="806" Name="生命木椅" />
+    <Item Id="807" Name="仙人掌椅" />
+    <Item Id="808" Name="骨头椅" />
+    <Item Id="809" Name="血肉椅" />
+    <Item Id="810" Name="蘑菇椅" />
+    <Item Id="811" Name="骨头工作台" />
+    <Item Id="812" Name="仙人掌工作台" />
+    <Item Id="813" Name="血肉工作台" />
+    <Item Id="814" Name="蘑菇工作台" />
+    <Item Id="815" Name="史莱姆工作台" />
+    <Item Id="816" Name="仙人掌门" />
+    <Item Id="817" Name="血肉门" />
+    <Item Id="818" Name="蘑菇门" />
+    <Item Id="819" Name="生命木门" />
+    <Item Id="820" Name="骨头门" />
+    <Item Id="821" Name="烈焰之翼" />
+    <Item Id="822" Name="冰冻之翼" />
+    <Item Id="823" Name="幽灵之翼" />
+    <Item Id="824" Name="日盘块" />
+    <Item Id="825" Name="飞盘墙" />
+    <Item Id="826" Name="天域椅" />
+    <Item Id="827" Name="骨头桌" />
+    <Item Id="828" Name="血肉桌" />
+    <Item Id="829" Name="生命木桌" />
+    <Item Id="830" Name="天域桌" />
+    <Item Id="831" Name="生命木箱" />
+    <Item Id="832" Name="生命木魔棒" />
+    <Item Id="833" Name="紫冰雪块" />
+    <Item Id="834" Name="粉冰雪块" />
+    <Item Id="835" Name="红冰雪块" />
+    <Item Id="836" Name="猩红石块" />
+    <Item Id="837" Name="天域门" />
+    <Item Id="838" Name="天域箱" />
+    <Item Id="839" Name="蒸汽朋克帽" Head="59" />
+    <Item Id="840" Name="蒸汽朋克衣" Body="39" />
+    <Item Id="841" Name="蒸汽朋克裤" Legs="37" />
+    <Item Id="842" Name="蜜蜂帽" Head="60" />
+    <Item Id="843" Name="蜜蜂衣" Body="40" />
+    <Item Id="844" Name="蜜蜂裤" Legs="38" />
+    <Item Id="845" Name="世界旗" />
+    <Item Id="846" Name="太阳旗" />
+    <Item Id="847" Name="重力旗" />
+    <Item Id="848" Name="法老面具" Head="61" />
+    <Item Id="849" Name="制动器" />
+    <Item Id="850" Name="蓝扳手" />
+    <Item Id="851" Name="绿扳手" />
+    <Item Id="852" Name="蓝压力板" />
+    <Item Id="853" Name="黄压力板" />
+    <Item Id="854" Name="优惠卡" />
+    <Item Id="855" Name="幸运币" />
+    <Item Id="856" Name="棒棒独角兽" />
+    <Item Id="857" Name="沙暴瓶" />
+    <Item Id="858" Name="针叶木沙发" />
+    <Item Id="859" Name="沙滩球" />
+    <Item Id="860" Name="神话护身符" />
+    <Item Id="861" Name="月亮贝壳" />
+    <Item Id="862" Name="星星面纱" />
+    <Item Id="863" Name="水上漂靴" />
+    <Item Id="864" Name="头冠" Head="62" />
+    <Item Id="865" Name="公主裙" Body="41" />
+    <Item Id="866" Name="法老长袍" Body="42" />
+    <Item Id="867" Name="绿帽" Head="63" />
+    <Item Id="868" Name="蘑菇帽" Head="64" />
+    <Item Id="869" Name="苏格兰便帽" Head="65" />
+    <Item Id="870" Name="木乃伊面具" Head="66" />
+    <Item Id="871" Name="木乃伊衣" Body="43" />
+    <Item Id="872" Name="木乃伊裤" Legs="39" />
+    <Item Id="873" Name="牛仔帽" Head="67" />
+    <Item Id="874" Name="牛仔夹克" Body="44" />
+    <Item Id="875" Name="牛仔裤" Legs="40" />
+    <Item Id="876" Name="海盗帽" Head="68" />
+    <Item Id="877" Name="海盗衣" Body="45" />
+    <Item Id="878" Name="海盗裤" Legs="41" />
+    <Item Id="879" Name="维京海盗头盔" Head="69" />
+    <Item Id="880" Name="猩红矿" />
+    <Item Id="881" Name="仙人掌剑" Rack="true" />
+    <Item Id="882" Name="仙人掌镐" Rack="true" />
+    <Item Id="883" Name="冰雪砖" />
+    <Item Id="884" Name="冰雪砖墙" />
+    <Item Id="885" Name="粘性绷带" />
+    <Item Id="886" Name="盔甲抛光剂" />
+    <Item Id="887" Name="牛黄" />
+    <Item Id="888" Name="蒙眼布" />
+    <Item Id="889" Name="快走时钟" />
+    <Item Id="890" Name="扩音器" />
+    <Item Id="891" Name="邪眼" />
+    <Item Id="892" Name="维生素" />
+    <Item Id="893" Name="三折地图" />
+    <Item Id="894" Name="仙人掌头盔" Head="70" />
+    <Item Id="895" Name="仙人掌胸甲" Body="46" />
+    <Item Id="896" Name="仙人掌护腿" Legs="42" />
+    <Item Id="897" Name="强力手套" />
+    <Item Id="898" Name="闪电靴" />
+    <Item Id="899" Name="太阳石" />
+    <Item Id="900" Name="月亮石" />
+    <Item Id="901" Name="盔甲背带" />
+    <Item Id="902" Name="药用绷带" />
+    <Item Id="903" Name="计划书" />
+    <Item Id="904" Name="反诅咒咒语" />
+    <Item Id="905" Name="钱币枪" Rack="true" />
+    <Item Id="906" Name="熔岩护身符" />
+    <Item Id="907" Name="黑曜石水上漂靴" />
+    <Item Id="908" Name="熔岩靴" />
+    <Item Id="909" Name="纯净喷泉" />
+    <Item Id="910" Name="沙漠喷泉" />
+    <Item Id="911" Name="暗影木" />
+    <Item Id="912" Name="暗影木门" />
+    <Item Id="913" Name="暗影木平台" />
+    <Item Id="914" Name="暗影木箱" />
+    <Item Id="915" Name="暗影木椅" />
+    <Item Id="916" Name="暗影木工作台" />
+    <Item Id="917" Name="暗影木桌" />
+    <Item Id="918" Name="暗影木梳妆台" />
+    <Item Id="919" Name="暗影木钢琴" />
+    <Item Id="920" Name="暗影木床" />
+    <Item Id="921" Name="暗影木剑" Rack="true" />
+    <Item Id="922" Name="暗影木锤" Scale="1.2" Rack="true" />
+    <Item Id="923" Name="暗影木弓" Rack="true" />
+    <Item Id="924" Name="暗影木头盔" Head="71" />
+    <Item Id="925" Name="暗影木胸甲" Body="47" />
+    <Item Id="926" Name="暗影木护胫" Legs="43" />
+    <Item Id="927" Name="暗影木墙" />
+    <Item Id="928" Name="大炮" />
+    <Item Id="929" Name="炮弹" Rack="true" />
+    <Item Id="930" Name="信号枪" Scale="0.9" Rack="true" />
+    <Item Id="931" Name="照明弹" Rack="true" />
+    <Item Id="932" Name="白骨魔棒" />
+    <Item Id="933" Name="树叶魔棒" />
+    <Item Id="934" Name="飞毯" />
+    <Item Id="935" Name="复仇者徽章" />
+    <Item Id="936" Name="机械手套" />
+    <Item Id="937" Name="地雷" />
+    <Item Id="938" Name="圣骑士护盾" />
+    <Item Id="939" Name="蛛丝吊索" />
+    <Item Id="940" Name="丛林喷泉" />
+    <Item Id="941" Name="冰雪喷泉" />
+    <Item Id="942" Name="腐化喷泉" />
+    <Item Id="943" Name="猩红喷泉" />
+    <Item Id="944" Name="神圣喷泉" />
+    <Item Id="945" Name="血水喷泉" />
+    <Item Id="946" Name="伞" />
+    <Item Id="947" Name="叶绿矿" />
+    <Item Id="948" Name="蒸汽朋克之翼" />
+    <Item Id="949" Name="雪球" Rack="true" />
+    <Item Id="950" Name="溜冰鞋" />
+    <Item Id="951" Name="雪球发射器" />
+    <Item Id="952" Name="蛛丝箱" />
+    <Item Id="953" Name="攀爬爪" />
+    <Item Id="954" Name="远古铁头盔" Head="72" />
+    <Item Id="955" Name="远古金头盔" Head="73" />
+    <Item Id="956" Name="远古暗影头盔" Head="74" />
+    <Item Id="957" Name="远古暗影鳞甲" Body="48" />
+    <Item Id="958" Name="远古暗影护胫" Legs="44" />
+    <Item Id="959" Name="远古死灵头盔" Head="75" />
+    <Item Id="960" Name="远古钴头盔" Head="76" />
+    <Item Id="961" Name="远古钴胸甲" Body="49" />
+    <Item Id="962" Name="远古钴护腿" Legs="45" />
+    <Item Id="963" Name="黑腰带" />
+    <Item Id="964" Name="三发猎枪" Rack="true" />
+    <Item Id="965" Name="绳" />
+    <Item Id="966" Name="篝火" />
+    <Item Id="967" Name="棉花糖" />
+    <Item Id="968" Name="棒棒棉花糖" />
+    <Item Id="969" Name="熟棉花糖" />
+    <Item Id="970" Name="红火箭" />
+    <Item Id="971" Name="绿火箭" />
+    <Item Id="972" Name="蓝火箭" />
+    <Item Id="973" Name="黄火箭" />
+    <Item Id="974" Name="冰雪火把" />
+    <Item Id="975" Name="鞋钉" />
+    <Item Id="976" Name="猛虎攀爬装备" />
+    <Item Id="977" Name="分趾厚底袜" />
+    <Item Id="978" Name="粉爱斯基摩兜帽" Head="77" />
+    <Item Id="979" Name="粉爱斯基摩大衣" Body="50" />
+    <Item Id="980" Name="粉爱斯基摩裤" Legs="46" />
+    <Item Id="981" Name="粉线" />
+    <Item Id="982" Name="魔力再生手环" />
+    <Item Id="983" Name="沙暴气球" />
+    <Item Id="984" Name="忍者大师装备" />
+    <Item Id="985" Name="绳圈" />
+    <Item Id="986" Name="吹箭筒" Rack="true" />
+    <Item Id="987" Name="暴雪瓶" />
+    <Item Id="988" Name="霜冻箭" Rack="true" />
+    <Item Id="989" Name="附魔剑" Scale="1.1" Rack="true" />
+    <Item Id="990" Name="镐斧" Scale="1.1" Rack="true" />
+    <Item Id="991" Name="钴战斧" Scale="1.1" Rack="true" />
+    <Item Id="992" Name="秘银战斧" Scale="1.1" Rack="true" />
+    <Item Id="993" Name="精金战斧" Scale="1.1" Rack="true" />
+    <Item Id="994" Name="吞噬怪骨头" />
+    <Item Id="995" Name="搅拌机" />
+    <Item Id="996" Name="绞肉机" />
+    <Item Id="997" Name="提炼机" />
+    <Item Id="998" Name="固化机" />
+    <Item Id="999" Name="琥珀" />
+    <Item Id="1000" Name="彩纸枪" />
+    <Item Id="1001" Name="叶绿面具" Head="78" />
+    <Item Id="1002" Name="叶绿头盔" Head="79" />
+    <Item Id="1003" Name="叶绿头饰" Head="80" />
+    <Item Id="1004" Name="叶绿板甲" Body="51" />
+    <Item Id="1005" Name="叶绿护胫" Legs="47" />
+    <Item Id="1006" Name="叶绿锭" />
+    <Item Id="1007" Name="红染料" />
+    <Item Id="1008" Name="橙染料" />
+    <Item Id="1009" Name="黄染料" />
+    <Item Id="1010" Name="橙绿染料" />
+    <Item Id="1011" Name="绿染料" />
+    <Item Id="1012" Name="青绿染料" />
+    <Item Id="1013" Name="青染料" />
+    <Item Id="1014" Name="天蓝染料" />
+    <Item Id="1015" Name="蓝染料" />
+    <Item Id="1016" Name="紫染料" />
+    <Item Id="1017" Name="蓝紫染料" />
+    <Item Id="1018" Name="粉染料" />
+    <Item Id="1019" Name="红黑染料" />
+    <Item Id="1020" Name="橙黑染料" />
+    <Item Id="1021" Name="黄黑染料" />
+    <Item Id="1022" Name="橙绿黑染料" />
+    <Item Id="1023" Name="绿黑染料" />
+    <Item Id="1024" Name="青绿黑染料" />
+    <Item Id="1025" Name="青黑染料" />
+    <Item Id="1026" Name="天蓝黑染料" />
+    <Item Id="1027" Name="蓝黑染料" />
+    <Item Id="1028" Name="紫黑染料" />
+    <Item Id="1029" Name="蓝紫黑染料" />
+    <Item Id="1030" Name="粉黑染料" />
+    <Item Id="1031" Name="红焰染料" />
+    <Item Id="1032" Name="红焰黑染料" />
+    <Item Id="1033" Name="绿焰染料" />
+    <Item Id="1034" Name="绿焰黑染料" />
+    <Item Id="1035" Name="蓝焰染料" />
+    <Item Id="1036" Name="蓝焰黑染料" />
+    <Item Id="1037" Name="银染料" />
+    <Item Id="1038" Name="淡红染料" />
+    <Item Id="1039" Name="淡橙染料" />
+    <Item Id="1040" Name="淡黄染料" />
+    <Item Id="1041" Name="淡橙绿染料" />
+    <Item Id="1042" Name="淡绿染料" />
+    <Item Id="1043" Name="淡青绿染料" />
+    <Item Id="1044" Name="淡青染料" />
+    <Item Id="1045" Name="淡天蓝染料" />
+    <Item Id="1046" Name="淡蓝染料" />
+    <Item Id="1047" Name="淡紫染料" />
+    <Item Id="1048" Name="淡蓝紫染料" />
+    <Item Id="1049" Name="淡粉染料" />
+    <Item Id="1050" Name="黑染料" />
+    <Item Id="1051" Name="红银染料" />
+    <Item Id="1052" Name="橙银染料" />
+    <Item Id="1053" Name="黄银染料" />
+    <Item Id="1054" Name="橙绿银染料" />
+    <Item Id="1055" Name="绿银染料" />
+    <Item Id="1056" Name="青绿银染料" />
+    <Item Id="1057" Name="青银染料" />
+    <Item Id="1058" Name="天蓝银染料" />
+    <Item Id="1059" Name="蓝银染料" />
+    <Item Id="1060" Name="紫银染料" />
+    <Item Id="1061" Name="蓝紫银染料" />
+    <Item Id="1062" Name="粉银染料" />
+    <Item Id="1063" Name="亮红焰染料" />
+    <Item Id="1064" Name="亮绿焰染料" />
+    <Item Id="1065" Name="亮蓝焰染料" />
+    <Item Id="1066" Name="彩虹染料" />
+    <Item Id="1067" Name="亮彩虹染料" />
+    <Item Id="1068" Name="渐变黄染料" />
+    <Item Id="1069" Name="渐变青染料" />
+    <Item Id="1070" Name="渐变蓝紫染料" />
+    <Item Id="1071" Name="漆刷" />
+    <Item Id="1072" Name="涂漆滚刷" />
+    <Item Id="1073" Name="红漆" />
+    <Item Id="1074" Name="橙漆" />
+    <Item Id="1075" Name="黄漆" />
+    <Item Id="1076" Name="橙绿漆" />
+    <Item Id="1077" Name="绿漆" />
+    <Item Id="1078" Name="青绿漆" />
+    <Item Id="1079" Name="青漆" />
+    <Item Id="1080" Name="天蓝漆" />
+    <Item Id="1081" Name="蓝漆" />
+    <Item Id="1082" Name="紫漆" />
+    <Item Id="1083" Name="蓝紫漆" />
+    <Item Id="1084" Name="粉漆" />
+    <Item Id="1085" Name="深红漆" />
+    <Item Id="1086" Name="深橙漆" />
+    <Item Id="1087" Name="深黄漆" />
+    <Item Id="1088" Name="深橙绿漆" />
+    <Item Id="1089" Name="深绿漆" />
+    <Item Id="1090" Name="深青绿漆" />
+    <Item Id="1091" Name="深青漆" />
+    <Item Id="1092" Name="深天蓝漆" />
+    <Item Id="1093" Name="深蓝漆" />
+    <Item Id="1094" Name="深紫漆" />
+    <Item Id="1095" Name="深蓝紫漆" />
+    <Item Id="1096" Name="深粉漆" />
+    <Item Id="1097" Name="黑漆" />
+    <Item Id="1098" Name="白漆" />
+    <Item Id="1099" Name="灰漆" />
+    <Item Id="1100" Name="漆铲" />
+    <Item Id="1101" Name="丛林蜥蜴砖" />
+    <Item Id="1102" Name="丛林蜥蜴砖墙" />
+    <Item Id="1103" Name="雪泥块" />
+    <Item Id="1104" Name="钯金矿" />
+    <Item Id="1105" Name="山铜矿" />
+    <Item Id="1106" Name="钛金矿" />
+    <Item Id="1107" Name="青绿蘑菇" />
+    <Item Id="1108" Name="绿蘑菇" />
+    <Item Id="1109" Name="天蓝花朵" />
+    <Item Id="1110" Name="黄万寿菊" />
+    <Item Id="1111" Name="蓝浆果" />
+    <Item Id="1112" Name="橙绿海藻" />
+    <Item Id="1113" Name="粉仙人球" />
+    <Item Id="1114" Name="橙血根草" />
+    <Item Id="1115" Name="红外壳" />
+    <Item Id="1116" Name="青外壳" />
+    <Item Id="1117" Name="蓝紫外壳" />
+    <Item Id="1118" Name="紫粘液" />
+    <Item Id="1119" Name="黑墨水" />
+    <Item Id="1120" Name="染缸" />
+    <Item Id="1121" Name="蜜蜂枪" Scale="0.8" Rack="true" />
+    <Item Id="1122" Name="疯狂飞斧" Rack="true" />
+    <Item Id="1123" Name="养蜂人" Scale="1.1" Rack="true" />
+    <Item Id="1124" Name="蜂巢" />
+    <Item Id="1125" Name="蜂蜜块" />
+    <Item Id="1126" Name="蜂巢墙" />
+    <Item Id="1127" Name="松脆蜂蜜块" />
+    <Item Id="1128" Name="蜂蜜桶" />
+    <Item Id="1129" Name="蜂巢魔棒" />
+    <Item Id="1130" Name="蜜蜂手榴弹" Rack="true" />
+    <Item Id="1131" Name="重力球" />
+    <Item Id="1132" Name="蜂窝" />
+    <Item Id="1133" Name="憎恶之蜂" />
+    <Item Id="1134" Name="蜂蜜瓶" />
+    <Item Id="1135" Name="雨帽" Head="81" />
+    <Item Id="1136" Name="雨衣" Body="52" />
+    <Item Id="1137" Name="丛林蜥蜴门" />
+    <Item Id="1138" Name="地牢门" />
+    <Item Id="1139" Name="铅门" />
+    <Item Id="1140" Name="铁门" />
+    <Item Id="1141" Name="神庙钥匙" />
+    <Item Id="1142" Name="丛林蜥蜴箱" />
+    <Item Id="1143" Name="丛林蜥蜴椅" />
+    <Item Id="1144" Name="丛林蜥蜴桌" />
+    <Item Id="1145" Name="丛林蜥蜴工作台" />
+    <Item Id="1146" Name="超级飞镖机关" />
+    <Item Id="1147" Name="烈焰机关" />
+    <Item Id="1148" Name="尖球机关" />
+    <Item Id="1149" Name="长矛机关" />
+    <Item Id="1150" Name="木尖刺" />
+    <Item Id="1151" Name="丛林蜥蜴压力板" />
+    <Item Id="1152" Name="丛林蜥蜴雕像" />
+    <Item Id="1153" Name="丛林蜥蜴看守人雕像" />
+    <Item Id="1154" Name="丛林蜥蜴守卫雕像" />
+    <Item Id="1155" Name="胡蜂枪" Rack="true" />
+    <Item Id="1156" Name="食人鱼枪" Scale="1.1" Rack="true" />
+    <Item Id="1157" Name="矮人法杖" Rack="true" />
+    <Item Id="1158" Name="矮人项链" />
+    <Item Id="1159" Name="提基面具" Head="82" />
+    <Item Id="1160" Name="提基衣" Body="53" />
+    <Item Id="1161" Name="提基裤" Legs="48" />
+    <Item Id="1162" Name="叶之翼" />
+    <Item Id="1163" Name="暴雪气球" />
+    <Item Id="1164" Name="气球束" />
+    <Item Id="1165" Name="蝙蝠之翼" />
+    <Item Id="1166" Name="骨剑" Scale="1.05" Rack="true" />
+    <Item Id="1167" Name="大力士甲虫" />
+    <Item Id="1168" Name="烟雾弹" />
+    <Item Id="1169" Name="骨头钥匙" />
+    <Item Id="1170" Name="花蜜" />
+    <Item Id="1171" Name="提基图腾" />
+    <Item Id="1172" Name="蜥蜴蛋" />
+    <Item Id="1173" Name="墓石碑" />
+    <Item Id="1174" Name="十字墓石碑" />
+    <Item Id="1175" Name="碑石" />
+    <Item Id="1176" Name="墓碑" />
+    <Item Id="1177" Name="方尖碑" />
+    <Item Id="1178" Name="吹叶机" Rack="true" />
+    <Item Id="1179" Name="叶绿弹" Rack="true" />
+    <Item Id="1180" Name="鹦鹉饼干" />
+    <Item Id="1181" Name="奇异发光蘑菇" />
+    <Item Id="1182" Name="幼苗" />
+    <Item Id="1183" Name="妖灵瓶" />
+    <Item Id="1184" Name="钯金锭" />
+    <Item Id="1185" Name="钯金剑" Scale="1.125" Rack="true" />
+    <Item Id="1186" Name="钯金刺矛" Scale="1.1" Rack="true" />
+    <Item Id="1187" Name="钯金连弩" Rack="true" />
+    <Item Id="1188" Name="钯金镐" Scale="1.15" Rack="true" />
+    <Item Id="1189" Name="钯金钻头" Rack="true" />
+    <Item Id="1190" Name="钯金链锯" Rack="true" />
+    <Item Id="1191" Name="山铜锭" />
+    <Item Id="1192" Name="山铜剑" Scale="1.17" Rack="true" />
+    <Item Id="1193" Name="山铜长戟" Scale="1.1" Rack="true" />
+    <Item Id="1194" Name="山铜连弩" Rack="true" />
+    <Item Id="1195" Name="山铜镐" Scale="1.15" Rack="true" />
+    <Item Id="1196" Name="山铜钻头" Rack="true" />
+    <Item Id="1197" Name="山铜链锯" Rack="true" />
+    <Item Id="1198" Name="钛金锭" />
+    <Item Id="1199" Name="钛金剑" Scale="1.2" Rack="true" />
+    <Item Id="1200" Name="钛金三叉戟" Scale="1.1" Rack="true" />
+    <Item Id="1201" Name="钛金连弩" Rack="true" />
+    <Item Id="1202" Name="钛金镐" Scale="1.15" Rack="true" />
+    <Item Id="1203" Name="钛金钻头" Rack="true" />
+    <Item Id="1204" Name="钛金链锯" Rack="true" />
+    <Item Id="1205" Name="钯金面具" Head="83" />
+    <Item Id="1206" Name="钯金头盔" Head="84" />
+    <Item Id="1207" Name="钯金头饰" Head="85" />
+    <Item Id="1208" Name="钯金胸甲" Body="54" />
+    <Item Id="1209" Name="钯金护腿" Legs="49" />
+    <Item Id="1210" Name="山铜面具" Head="86" />
+    <Item Id="1211" Name="山铜头盔" Head="87" />
+    <Item Id="1212" Name="山铜头饰" Head="88" />
+    <Item Id="1213" Name="山铜胸甲" Body="55" />
+    <Item Id="1214" Name="山铜护腿" Legs="50" />
+    <Item Id="1215" Name="钛金面具" Head="89" />
+    <Item Id="1216" Name="钛金头盔" Head="90" />
+    <Item Id="1217" Name="钛金头饰" Head="91" />
+    <Item Id="1218" Name="钛金胸甲" Body="56" />
+    <Item Id="1219" Name="钛金护腿" Legs="51" />
+    <Item Id="1220" Name="山铜砧" />
+    <Item Id="1221" Name="钛金熔炉" />
+    <Item Id="1222" Name="钯金战斧" Scale="1.1" Rack="true" />
+    <Item Id="1223" Name="山铜战斧" Scale="1.1" Rack="true" />
+    <Item Id="1224" Name="钛金战斧" Scale="1.1" Rack="true" />
+    <Item Id="1225" Name="神圣锭" />
+    <Item Id="1226" Name="叶绿双刃刀" Scale="1.25" Rack="true" />
+    <Item Id="1227" Name="叶绿军刀" Rack="true" />
+    <Item Id="1228" Name="叶绿镋" Scale="1.1" Rack="true" />
+    <Item Id="1229" Name="叶绿连弩" Rack="true" />
+    <Item Id="1230" Name="叶绿镐" Scale="1.15" Rack="true" />
+    <Item Id="1231" Name="叶绿钻头" Rack="true" />
+    <Item Id="1232" Name="叶绿链锯" Rack="true" />
+    <Item Id="1233" Name="叶绿巨斧" Scale="1.15" Rack="true" />
+    <Item Id="1234" Name="叶绿战锤" Scale="1.25" Rack="true" />
+    <Item Id="1235" Name="叶绿箭" Rack="true" />
+    <Item Id="1236" Name="紫晶钩" />
+    <Item Id="1237" Name="黄玉钩" />
+    <Item Id="1238" Name="蓝玉钩" />
+    <Item Id="1239" Name="翡翠钩" />
+    <Item Id="1240" Name="红玉钩" />
+    <Item Id="1241" Name="钻石钩" />
+    <Item Id="1242" Name="蚊子琥珀" />
+    <Item Id="1243" Name="伞帽" Head="92" />
+    <Item Id="1244" Name="雨云魔杖" Rack="true" />
+    <Item Id="1245" Name="橙火把" />
+    <Item Id="1246" Name="猩红沙块" />
+    <Item Id="1247" Name="蜜蜂斗篷" />
+    <Item Id="1248" Name="石巨人之眼" />
+    <Item Id="1249" Name="蜂蜜气球" />
+    <Item Id="1250" Name="蓝马掌气球" />
+    <Item Id="1251" Name="白马掌气球" />
+    <Item Id="1252" Name="黄马掌气球" />
+    <Item Id="1253" Name="冰冻海龟壳" />
+    <Item Id="1254" Name="狙击步枪" Rack="true" />
+    <Item Id="1255" Name="维纳斯万能枪" Scale="0.85" Rack="true" />
+    <Item Id="1256" Name="猩红魔杖" Rack="true" />
+    <Item Id="1257" Name="猩红矿锭" />
+    <Item Id="1258" Name="毒刺发射器" Rack="true" />
+    <Item Id="1259" Name="花冠" Scale="1.1" Rack="true" />
+    <Item Id="1260" Name="彩虹枪" Rack="true" />
+    <Item Id="1261" Name="毒刺矢" Rack="true" />
+    <Item Id="1262" Name="叶绿手提钻" Rack="true" />
+    <Item Id="1263" Name="传送机" />
+    <Item Id="1264" Name="寒霜之花" Rack="true" />
+    <Item Id="1265" Name="乌兹冲锋枪" Scale="0.75" Rack="true" />
+    <Item Id="1266" Name="磁球" Rack="true" />
+    <Item Id="1267" Name="紫花窗玻璃" />
+    <Item Id="1268" Name="黄花窗玻璃" />
+    <Item Id="1269" Name="蓝花窗玻璃" />
+    <Item Id="1270" Name="绿花窗玻璃" />
+    <Item Id="1271" Name="红花窗玻璃" />
+    <Item Id="1272" Name="五彩花窗玻璃" />
+    <Item Id="1273" Name="骷髅王之手" />
+    <Item Id="1274" Name="骷髅头" Head="93" />
+    <Item Id="1275" Name="巴拉帽" Head="94" />
+    <Item Id="1276" Name="黑帮帽" Head="95" />
+    <Item Id="1277" Name="水手帽" Head="96" />
+    <Item Id="1278" Name="眼罩" Head="97" />
+    <Item Id="1279" Name="水手衣" Body="57" />
+    <Item Id="1280" Name="水手裤" Legs="52" />
+    <Item Id="1281" Name="骷髅王面具" Head="98" />
+    <Item Id="1282" Name="紫晶长袍" Body="58" />
+    <Item Id="1283" Name="黄玉长袍" Body="59" />
+    <Item Id="1284" Name="蓝玉长袍" Body="60" />
+    <Item Id="1285" Name="翡翠长袍" Body="61" />
+    <Item Id="1286" Name="红玉长袍" Body="62" />
+    <Item Id="1287" Name="钻石长袍" Body="63" />
+    <Item Id="1288" Name="白西装衣" Body="64" />
+    <Item Id="1289" Name="白西装裤" Legs="53" />
+    <Item Id="1290" Name="恐慌项链" />
+    <Item Id="1291" Name="生命果" />
+    <Item Id="1292" Name="丛林蜥蜴祭坛" />
+    <Item Id="1293" Name="丛林蜥蜴电池" />
+    <Item Id="1294" Name="锯刃镐" Scale="1.15" Rack="true" />
+    <Item Id="1295" Name="高温射线枪" Rack="true" />
+    <Item Id="1296" Name="大地法杖" Rack="true" />
+    <Item Id="1297" Name="石巨人之拳" Scale="0.9" Rack="true" />
+    <Item Id="1298" Name="水中箱" />
+    <Item Id="1299" Name="双筒望远镜" />
+    <Item Id="1300" Name="步枪瞄准镜" />
+    <Item Id="1301" Name="毁灭者徽章" />
+    <Item Id="1302" Name="高射速子弹" Rack="true" />
+    <Item Id="1303" Name="水母项链" />
+    <Item Id="1304" Name="僵尸臂" Rack="true" />
+    <Item Id="1305" Name="斧" Scale="1.15" Rack="true" />
+    <Item Id="1306" Name="冰雪镰刀" Scale="1.15" Rack="true" />
+    <Item Id="1307" Name="服装商巫毒娃娃" />
+    <Item Id="1308" Name="剧毒法杖" Rack="true" />
+    <Item Id="1309" Name="史莱姆法杖" />
+    <Item Id="1310" Name="毒镖" Rack="true" />
+    <Item Id="1311" Name="弹簧眼" />
+    <Item Id="1312" Name="玩具雪橇" />
+    <Item Id="1313" Name="骷髅头法书" Scale="0.9" Rack="true" />
+    <Item Id="1314" Name="致胜炮" Scale="0.9" Rack="true" />
+    <Item Id="1315" Name="海盗地图" />
+    <Item Id="1316" Name="海龟头盔" Head="99" />
+    <Item Id="1317" Name="海龟铠甲" Body="65" />
+    <Item Id="1318" Name="海龟护腿" Legs="54" />
+    <Item Id="1319" Name="雪球炮" Rack="true" />
+    <Item Id="1320" Name="骨镐" Scale="1.15" Rack="true" />
+    <Item Id="1321" Name="魔法箭袋" />
+    <Item Id="1322" Name="岩浆石" />
+    <Item Id="1323" Name="黑曜石玫瑰" />
+    <Item Id="1324" Name="香蕉回旋镖" Rack="true" />
+    <Item Id="1325" Name="链刀" Rack="true" />
+    <Item Id="1326" Name="混沌传送杖" Rack="true" />
+    <Item Id="1327" Name="死神镰刀" Scale="1.15" Rack="true" />
+    <Item Id="1328" Name="海龟壳" />
+    <Item Id="1329" Name="组织样本" />
+    <Item Id="1330" Name="椎骨" />
+    <Item Id="1331" Name="血腥脊椎" />
+    <Item Id="1332" Name="灵液" />
+    <Item Id="1333" Name="灵液火把" />
+    <Item Id="1334" Name="灵液箭" Rack="true" />
+    <Item Id="1335" Name="灵液弹" Rack="true" />
+    <Item Id="1336" Name="黄金雨" Rack="true" />
+    <Item Id="1337" Name="兔兔炮" />
+    <Item Id="1338" Name="爆炸兔" Rack="true" />
+    <Item Id="1339" Name="小瓶毒液" />
+    <Item Id="1340" Name="大瓶毒液" />
+    <Item Id="1341" Name="毒液箭" Rack="true" />
+    <Item Id="1342" Name="毒液弹" Rack="true" />
+    <Item Id="1343" Name="烈火手套" />
+    <Item Id="1344" Name="齿轮" />
+    <Item Id="1345" Name="彩纸" />
+    <Item Id="1346" Name="纳米机器人" />
+    <Item Id="1347" Name="爆炸粉" />
+    <Item Id="1348" Name="金尘" />
+    <Item Id="1349" Name="派对弹" Rack="true" />
+    <Item Id="1350" Name="纳米弹" Rack="true" />
+    <Item Id="1351" Name="爆破弹" Rack="true" />
+    <Item Id="1352" Name="金子弹" Rack="true" />
+    <Item Id="1353" Name="诅咒焰瓶" />
+    <Item Id="1354" Name="烈火瓶" />
+    <Item Id="1355" Name="金瓶" />
+    <Item Id="1356" Name="灵液瓶" />
+    <Item Id="1357" Name="纳米机器人之瓶" />
+    <Item Id="1358" Name="派对瓶" />
+    <Item Id="1359" Name="毒药瓶" />
+    <Item Id="1360" Name="克苏鲁之眼纪念章" />
+    <Item Id="1361" Name="世界吞噬怪纪念章" />
+    <Item Id="1362" Name="克苏鲁之脑纪念章" />
+    <Item Id="1363" Name="骷髅王纪念章" />
+    <Item Id="1364" Name="蜂王纪念章" />
+    <Item Id="1365" Name="血肉墙纪念章" />
+    <Item Id="1366" Name="毁灭者纪念章" />
+    <Item Id="1367" Name="机械骷髅王纪念章" />
+    <Item Id="1368" Name="激光眼纪念章" />
+    <Item Id="1369" Name="魔焰眼纪念章" />
+    <Item Id="1370" Name="世纪之花纪念章" />
+    <Item Id="1371" Name="石巨人纪念章" />
+    <Item Id="1372" Name="血月升空" />
+    <Item Id="1373" Name="倒吊人" />
+    <Item Id="1374" Name="烈火荣耀" />
+    <Item Id="1375" Name="扭曲的骨头" />
+    <Item Id="1376" Name="壁挂骷髅" />
+    <Item Id="1377" Name="吊挂骷髅" />
+    <Item Id="1378" Name="蓝板墙" />
+    <Item Id="1379" Name="蓝瓷砖墙" />
+    <Item Id="1380" Name="粉板墙" />
+    <Item Id="1381" Name="粉瓷砖墙" />
+    <Item Id="1382" Name="绿板墙" />
+    <Item Id="1383" Name="绿瓷砖墙" />
+    <Item Id="1384" Name="蓝砖平台" />
+    <Item Id="1385" Name="粉砖平台" />
+    <Item Id="1386" Name="绿砖平台" />
+    <Item Id="1387" Name="金属架" />
+    <Item Id="1388" Name="黄铜架" />
+    <Item Id="1389" Name="木架" />
+    <Item Id="1390" Name="黄铜灯笼" />
+    <Item Id="1391" Name="笼式灯笼" />
+    <Item Id="1392" Name="马车灯笼" />
+    <Item Id="1393" Name="炼金灯笼" />
+    <Item Id="1394" Name="魔教徒灯" />
+    <Item Id="1395" Name="油布烛台" />
+    <Item Id="1396" Name="蓝地牢椅" />
+    <Item Id="1397" Name="蓝地牢桌" />
+    <Item Id="1398" Name="蓝地牢工作台" />
+    <Item Id="1399" Name="绿地牢椅" />
+    <Item Id="1400" Name="绿地牢桌" />
+    <Item Id="1401" Name="绿地牢工作台" />
+    <Item Id="1402" Name="粉地牢椅" />
+    <Item Id="1403" Name="粉地牢桌" />
+    <Item Id="1404" Name="粉地牢工作台" />
+    <Item Id="1405" Name="蓝地牢蜡烛" />
+    <Item Id="1406" Name="绿地牢蜡烛" />
+    <Item Id="1407" Name="粉地牢蜡烛" />
+    <Item Id="1408" Name="蓝地牢花瓶" />
+    <Item Id="1409" Name="绿地牢花瓶" />
+    <Item Id="1410" Name="粉地牢花瓶" />
+    <Item Id="1411" Name="蓝地牢门" />
+    <Item Id="1412" Name="绿地牢门" />
+    <Item Id="1413" Name="粉地牢门" />
+    <Item Id="1414" Name="蓝地牢书架" />
+    <Item Id="1415" Name="绿地牢书架" />
+    <Item Id="1416" Name="粉地牢书架" />
+    <Item Id="1417" Name="地下墓穴" />
+    <Item Id="1418" Name="地牢架" />
+    <Item Id="1419" Name="骷髅杰克" />
+    <Item Id="1420" Name="被诅咒的人" />
+    <Item Id="1421" Name="最后一眼" />
+    <Item Id="1422" Name="恶魔注视" />
+    <Item Id="1423" Name="苏醒的双子魔眼" />
+    <Item Id="1424" Name="呐喊者" />
+    <Item Id="1425" Name="玩扑克牌的哥布林" />
+    <Item Id="1426" Name="树妖女" />
+    <Item Id="1427" Name="向日葵" />
+    <Item Id="1428" Name="泰拉式哥特" />
+    <Item Id="1429" Name="小便帽" Head="100" />
+    <Item Id="1430" Name="灌注站" />
+    <Item Id="1431" Name="星星瓶" />
+    <Item Id="1432" Name="空心子弹" />
+    <Item Id="1433" Name="碰撞" />
+    <Item Id="1434" Name="鸟力驱动" />
+    <Item Id="1435" Name="毁灭者" />
+    <Item Id="1436" Name="永恒之眼" />
+    <Item Id="1437" Name="越过神圣之地的独角兽" />
+    <Item Id="1438" Name="巨浪" />
+    <Item Id="1439" Name="星空" />
+    <Item Id="1440" Name="向导毕加索" />
+    <Item Id="1441" Name="守卫凝视" />
+    <Item Id="1442" Name="某人之父" />
+    <Item Id="1443" Name="丽莎护士" />
+    <Item Id="1444" Name="暗影束法杖" Rack="true" />
+    <Item Id="1445" Name="狱火叉" Rack="true" />
+    <Item Id="1446" Name="幽灵法杖" Rack="true" />
+    <Item Id="1447" Name="木栅栏" />
+    <Item Id="1448" Name="铅栅栏" />
+    <Item Id="1449" Name="泡泡机" />
+    <Item Id="1450" Name="泡泡魔棒" />
+    <Item Id="1451" Name="骷髅行军旗" />
+    <Item Id="1452" Name="死灵标旗" />
+    <Item Id="1453" Name="秀逗连队旗" />
+    <Item Id="1454" Name="丐帮帮旗" />
+    <Item Id="1455" Name="熔火军团旗" />
+    <Item Id="1456" Name="魔教旗" />
+    <Item Id="1457" Name="黑曜石平台" />
+    <Item Id="1458" Name="黑曜石门" />
+    <Item Id="1459" Name="黑曜石椅" />
+    <Item Id="1460" Name="黑曜石桌" />
+    <Item Id="1461" Name="黑曜石工作台" />
+    <Item Id="1462" Name="黑曜石花瓶" />
+    <Item Id="1463" Name="黑曜石书架" />
+    <Item Id="1464" Name="地狱之界旗" />
+    <Item Id="1465" Name="地狱之锤旗" />
+    <Item Id="1466" Name="地狱之塔旗" />
+    <Item Id="1467" Name="绝望人旗" />
+    <Item Id="1468" Name="黑曜石看守人旗" />
+    <Item Id="1469" Name="熔岩喷液旗" />
+    <Item Id="1470" Name="蓝地牢床" />
+    <Item Id="1471" Name="绿地牢床" />
+    <Item Id="1472" Name="粉地牢床" />
+    <Item Id="1473" Name="黑曜石床" />
+    <Item Id="1474" Name="沃尔多" />
+    <Item Id="1475" Name="黑暗" />
+    <Item Id="1476" Name="暗魂死神" />
+    <Item Id="1477" Name="大地" />
+    <Item Id="1478" Name="受困鬼魂" />
+    <Item Id="1479" Name="恶魔眼" />
+    <Item Id="1480" Name="淘金" />
+    <Item Id="1481" Name="初次邂逅" />
+    <Item Id="1482" Name="早安" />
+    <Item Id="1483" Name="地下馈赠" />
+    <Item Id="1484" Name="窗外" />
+    <Item Id="1485" Name="云之上" />
+    <Item Id="1486" Name="请勿践踏草坪" />
+    <Item Id="1487" Name="冰雪寒溪" />
+    <Item Id="1488" Name="阴暗幽谷" />
+    <Item Id="1489" Name="浮华假象的大地" />
+    <Item Id="1490" Name="黎明" />
+    <Item Id="1491" Name="沙漠的秘密" />
+    <Item Id="1492" Name="死地复生" />
+    <Item Id="1493" Name="恶灵现世" />
+    <Item Id="1494" Name="天空守卫" />
+    <Item Id="1495" Name="美洲爆炸狂" />
+    <Item Id="1496" Name="探索" />
+    <Item Id="1497" Name="大地之手" />
+    <Item Id="1498" Name="老矿工" />
+    <Item Id="1499" Name="骨蛇之头" />
+    <Item Id="1500" Name="直面摄魂师" />
+    <Item Id="1501" Name="火湖" />
+    <Item Id="1502" Name="超级英雄三剑客" />
+    <Item Id="1503" Name="幽灵兜帽" Head="101" />
+    <Item Id="1504" Name="幽灵长袍" Body="66" />
+    <Item Id="1505" Name="幽灵裤" Legs="55" />
+    <Item Id="1506" Name="幽灵镐" Scale="1.15" Rack="true" />
+    <Item Id="1507" Name="幽灵锤斧" Scale="1.05" Rack="true" />
+    <Item Id="1508" Name="灵气" />
+    <Item Id="1509" Name="哥特椅" />
+    <Item Id="1510" Name="哥特桌" />
+    <Item Id="1511" Name="哥特工作台" />
+    <Item Id="1512" Name="哥特书架" />
+    <Item Id="1513" Name="圣骑士锤" Rack="true" />
+    <Item Id="1514" Name="特战头盔" Head="102" />
+    <Item Id="1515" Name="蜜蜂之翼" />
+    <Item Id="1516" Name="巨型鸟妖之羽" />
+    <Item Id="1517" Name="骨之羽" />
+    <Item Id="1518" Name="火羽" />
+    <Item Id="1519" Name="冰雪羽" />
+    <Item Id="1520" Name="破蝙蝠之翼" />
+    <Item Id="1521" Name="褴褛蜜蜂之翼" />
+    <Item Id="1522" Name="大紫晶" />
+    <Item Id="1523" Name="大黄玉" />
+    <Item Id="1524" Name="大蓝玉" />
+    <Item Id="1525" Name="大翡翠" />
+    <Item Id="1526" Name="大红玉" />
+    <Item Id="1527" Name="大钻石" />
+    <Item Id="1528" Name="丛林箱" />
+    <Item Id="1529" Name="腐化箱" />
+    <Item Id="1530" Name="猩红箱" />
+    <Item Id="1531" Name="神圣箱" />
+    <Item Id="1532" Name="冰冻箱" />
+    <Item Id="1533" Name="丛林钥匙" />
+    <Item Id="1534" Name="腐化钥匙" />
+    <Item Id="1535" Name="猩红钥匙" />
+    <Item Id="1536" Name="神圣钥匙" />
+    <Item Id="1537" Name="冰冻钥匙" />
+    <Item Id="1538" Name="小鬼脸" />
+    <Item Id="1539" Name="凶兆" />
+    <Item Id="1540" Name="闪亮月亮" />
+    <Item Id="1541" Name="血肉之躯" />
+    <Item Id="1542" Name="岩浆漫流" />
+    <Item Id="1543" Name="幽灵漆刷" />
+    <Item Id="1544" Name="幽灵涂漆滚刷" />
+    <Item Id="1545" Name="幽灵漆铲" />
+    <Item Id="1546" Name="蘑菇矿头饰" Head="103" />
+    <Item Id="1547" Name="蘑菇矿面具" Head="104" />
+    <Item Id="1548" Name="蘑菇矿头盔" Head="105" />
+    <Item Id="1549" Name="蘑菇矿胸甲" Body="67" />
+    <Item Id="1550" Name="蘑菇矿护腿" Legs="56" />
+    <Item Id="1551" Name="自动锤炼机" />
+    <Item Id="1552" Name="蘑菇矿锭" />
+    <Item Id="1553" Name="太空海豚机枪" Rack="true" />
+    <Item Id="1554" Name="Cenx的头冠" Head="106" />
+    <Item Id="1555" Name="Cenx的胸甲" Body="68" />
+    <Item Id="1556" Name="Cenx的护腿" Legs="57" />
+    <Item Id="1557" Name="Crowno的面具" Head="107" />
+    <Item Id="1558" Name="Crowno的胸甲" Body="69" />
+    <Item Id="1559" Name="Crowno的护腿" Legs="58" />
+    <Item Id="1560" Name="Will的头盔" Head="108" />
+    <Item Id="1561" Name="Will的胸甲" Body="70" />
+    <Item Id="1562" Name="Will的护腿" Legs="59" />
+    <Item Id="1563" Name="Jim的头盔" Head="109" />
+    <Item Id="1564" Name="Jim的胸甲" Body="71" />
+    <Item Id="1565" Name="Jim的护腿" Legs="60" />
+    <Item Id="1566" Name="Aaron的头盔" Head="110" />
+    <Item Id="1567" Name="Aaron的胸甲" Body="72" />
+    <Item Id="1568" Name="Aaron的护腿" Legs="61" />
+    <Item Id="1569" Name="吸血鬼刀" Rack="true" />
+    <Item Id="1570" Name="断裂英雄剑" />
+    <Item Id="1571" Name="腐化者之戟" Rack="true" />
+    <Item Id="1572" Name="寒霜九头蛇法杖" Rack="true" />
+    <Item Id="1573" Name="创造向导" />
+    <Item Id="1574" Name="商人" />
+    <Item Id="1575" Name="Crowno吞噬其餐" />
+    <Item Id="1576" Name="稀有魔力" />
+    <Item Id="1577" Name="荣耀之夜" />
+    <Item Id="1578" Name="甜心项链" />
+    <Item Id="1579" Name="疾风雪靴" />
+    <Item Id="1580" Name="D-Town的头盔" Head="111" />
+    <Item Id="1581" Name="D-Town的胸甲" Body="73" />
+    <Item Id="1582" Name="D-Town的护腿" Legs="62" />
+    <Item Id="1583" Name="D-Town的翅膀" />
+    <Item Id="1584" Name="Will的翅膀" />
+    <Item Id="1585" Name="Crowno的翅膀" />
+    <Item Id="1586" Name="Cenx的翅膀" />
+    <Item Id="1587" Name="Cenx的上衣" Body="74" />
+    <Item Id="1588" Name="Cenx的裤装" Legs="63" />
+    <Item Id="1589" Name="钯金柱" />
+    <Item Id="1590" Name="钯金柱墙" />
+    <Item Id="1591" Name="泡泡糖块" />
+    <Item Id="1592" Name="泡泡糖块墙" />
+    <Item Id="1593" Name="钛石块" />
+    <Item Id="1594" Name="钛石块墙" />
+    <Item Id="1595" Name="魔法手铐" />
+    <Item Id="1596" Name="八音盒（雪原）" />
+    <Item Id="1597" Name="八音盒（太空）" />
+    <Item Id="1598" Name="八音盒（猩红之地）" />
+    <Item Id="1599" Name="八音盒(Boss 4)" />
+    <Item Id="1600" Name="八音盒（人间日备选曲）" />
+    <Item Id="1601" Name="八音盒（雨）" />
+    <Item Id="1602" Name="八音盒（冰雪）" />
+    <Item Id="1603" Name="八音盒（沙漠）" />
+    <Item Id="1604" Name="八音盒（海洋）" />
+    <Item Id="1605" Name="八音盒（地牢）" />
+    <Item Id="1606" Name="八音盒（世纪之花）" />
+    <Item Id="1607" Name="八音盒(Boss 5)" />
+    <Item Id="1608" Name="八音盒（神庙）" />
+    <Item Id="1609" Name="八音盒（日食）" />
+    <Item Id="1610" Name="八音盒（蘑菇）" />
+    <Item Id="1611" Name="蝴蝶尘" />
+    <Item Id="1612" Name="十字章护身符" />
+    <Item Id="1613" Name="十字章护盾" />
+    <Item Id="1614" Name="蓝照明弹" Rack="true" />
+    <Item Id="1615" Name="琵琶鱼旗" Tally="1" />
+    <Item Id="1616" Name="愤怒雨云怪旗" Tally="2" />
+    <Item Id="1617" Name="歪尾真菌旗" Tally="3" />
+    <Item Id="1618" Name="蚁狮旗" Tally="4" />
+    <Item Id="1619" Name="巨骨舌鱼旗" Tally="5" />
+    <Item Id="1620" Name="装甲骷髅旗" Tally="6" />
+    <Item Id="1621" Name="洞穴蝙蝠旗" Tally="7" />
+    <Item Id="1622" Name="鸟旗" Tally="8" />
+    <Item Id="1623" Name="黑隐士旗" Tally="9" />
+    <Item Id="1624" Name="嗜血怪旗" Tally="10" />
+    <Item Id="1625" Name="血水母旗" Tally="11" />
+    <Item Id="1626" Name="血爬虫旗" Tally="12" />
+    <Item Id="1627" Name="骨蛇旗" Tally="13" />
+    <Item Id="1628" Name="兔兔旗" Tally="14" />
+    <Item Id="1629" Name="混沌精旗" Tally="15" />
+    <Item Id="1630" Name="宝箱怪旗" Tally="16" />
+    <Item Id="1631" Name="小丑旗" Tally="17" />
+    <Item Id="1632" Name="腐化兔兔旗" Tally="18" />
+    <Item Id="1633" Name="腐化金鱼旗" Tally="19" />
+    <Item Id="1634" Name="螃蟹旗" Tally="20" />
+    <Item Id="1635" Name="猩红喀迈拉旗" Tally="21" />
+    <Item Id="1636" Name="猩红斧旗" Tally="22" />
+    <Item Id="1637" Name="诅咒锤旗" Tally="23" />
+    <Item Id="1638" Name="恶魔旗" Tally="24" />
+    <Item Id="1639" Name="恶魔眼旗" Tally="25" />
+    <Item Id="1640" Name="跳跳兽旗" Tally="26" />
+    <Item Id="1641" Name="噬魂怪旗" Tally="27" />
+    <Item Id="1642" Name="附魔剑旗" Tally="28" />
+    <Item Id="1643" Name="爱斯基摩僵尸旗" Tally="29" />
+    <Item Id="1644" Name="脸怪旗" Tally="30" />
+    <Item Id="1645" Name="恶心浮游怪旗" Tally="31" />
+    <Item Id="1646" Name="飞鱼旗" Tally="32" />
+    <Item Id="1647" Name="飞蛇旗" Tally="33" />
+    <Item Id="1648" Name="科学怪人旗" Tally="34" />
+    <Item Id="1649" Name="真菌球怪旗" Tally="35" />
+    <Item Id="1650" Name="蘑菇鱼旗" Tally="36" />
+    <Item Id="1651" Name="腹足怪旗" Tally="37" />
+    <Item Id="1652" Name="哥布林盗贼旗" Tally="38" />
+    <Item Id="1653" Name="哥布林巫士旗" Tally="39" />
+    <Item Id="1654" Name="哥布林苦力旗" Tally="40" />
+    <Item Id="1655" Name="哥布林侦察兵旗" Tally="41" />
+    <Item Id="1656" Name="哥布林战士旗" Tally="42" />
+    <Item Id="1657" Name="金鱼旗" Tally="43" />
+    <Item Id="1658" Name="鸟妖旗" Tally="44" />
+    <Item Id="1659" Name="地狱蝙蝠旗" Tally="45" />
+    <Item Id="1660" Name="蹦蹦兽旗" Tally="46" />
+    <Item Id="1661" Name="黄蜂旗" Tally="47" />
+    <Item Id="1662" Name="冰雪精旗" Tally="48" />
+    <Item Id="1663" Name="冰雪人鱼旗" Tally="49" />
+    <Item Id="1664" Name="火焰小鬼旗" Tally="50" />
+    <Item Id="1665" Name="蓝水母旗" Tally="51" />
+    <Item Id="1666" Name="丛林蜘蛛旗" Tally="52" />
+    <Item Id="1667" Name="丛林蜥蜴旗" Tally="53" />
+    <Item Id="1668" Name="食人怪旗" Tally="54" />
+    <Item Id="1669" Name="流星头旗" Tally="55" />
+    <Item Id="1670" Name="飞蛾旗" Tally="56" />
+    <Item Id="1671" Name="木乃伊旗" Tally="57" />
+    <Item Id="1672" Name="瓢虫旗" Tally="58" />
+    <Item Id="1673" Name="鹦鹉旗" Tally="59" />
+    <Item Id="1674" Name="猪龙旗" Tally="60" />
+    <Item Id="1675" Name="食人鱼旗" Tally="61" />
+    <Item Id="1676" Name="海盗水手旗" Tally="62" />
+    <Item Id="1677" Name="妖精旗" Tally="63" />
+    <Item Id="1678" Name="雨衣僵尸旗" Tally="64" />
+    <Item Id="1679" Name="死神旗" Tally="65" />
+    <Item Id="1680" Name="鲨鱼旗" Tally="66" />
+    <Item Id="1681" Name="骷髅旗" Tally="67" />
+    <Item Id="1682" Name="暗黑法师旗" Tally="68" />
+    <Item Id="1683" Name="蓝史莱姆旗" Tally="69" />
+    <Item Id="1684" Name="小雪怪旗" Tally="70" />
+    <Item Id="1685" Name="爬墙蜘蛛旗" Tally="71" />
+    <Item Id="1686" Name="孢子僵尸旗" Tally="72" />
+    <Item Id="1687" Name="沼泽怪旗" Tally="73" />
+    <Item Id="1688" Name="巨型陆龟旗" Tally="74" />
+    <Item Id="1689" Name="毒泥旗" Tally="75" />
+    <Item Id="1690" Name="雨伞史莱姆旗" Tally="76" />
+    <Item Id="1691" Name="独角兽旗" Tally="77" />
+    <Item Id="1692" Name="吸血鬼旗" Tally="78" />
+    <Item Id="1693" Name="秃鹰旗" Tally="79" />
+    <Item Id="1694" Name="宁芙旗" Tally="80" />
+    <Item Id="1695" Name="狼人旗" Tally="81" />
+    <Item Id="1696" Name="狼旗" Tally="82" />
+    <Item Id="1697" Name="吞世怪旗" Tally="83" />
+    <Item Id="1698" Name="蠕虫旗" Tally="84" />
+    <Item Id="1699" Name="幻灵旗" Tally="85" />
+    <Item Id="1700" Name="飞龙旗" Tally="86" />
+    <Item Id="1701" Name="僵尸旗" Tally="87" />
+    <Item Id="1702" Name="玻璃平台" />
+    <Item Id="1703" Name="玻璃椅" />
+    <Item Id="1704" Name="金椅" />
+    <Item Id="1705" Name="金马桶" />
+    <Item Id="1706" Name="高脚凳" />
+    <Item Id="1707" Name="蜂蜜椅" />
+    <Item Id="1708" Name="蒸汽朋克椅" />
+    <Item Id="1709" Name="玻璃门" />
+    <Item Id="1710" Name="金门" />
+    <Item Id="1711" Name="蜂蜜门" />
+    <Item Id="1712" Name="蒸汽朋克门" />
+    <Item Id="1713" Name="玻璃桌" />
+    <Item Id="1714" Name="宴会桌" />
+    <Item Id="1715" Name="锭" />
+    <Item Id="1716" Name="金桌" />
+    <Item Id="1717" Name="蜂蜜桌" />
+    <Item Id="1718" Name="蒸汽朋克桌" />
+    <Item Id="1719" Name="玻璃床" />
+    <Item Id="1720" Name="金床" />
+    <Item Id="1721" Name="蜂蜜床" />
+    <Item Id="1722" Name="蒸汽朋克床" />
+    <Item Id="1723" Name="生命木墙" />
+    <Item Id="1724" Name="罐中臭屁" />
+    <Item Id="1725" Name="南瓜" />
+    <Item Id="1726" Name="南瓜墙" />
+    <Item Id="1727" Name="干草" />
+    <Item Id="1728" Name="干草墙" />
+    <Item Id="1729" Name="阴森木" />
+    <Item Id="1730" Name="阴森木墙" />
+    <Item Id="1731" Name="南瓜头盔" Head="112" />
+    <Item Id="1732" Name="南瓜胸甲" Body="75" />
+    <Item Id="1733" Name="南瓜护腿" Legs="64" />
+    <Item Id="1734" Name="焦糖苹果" />
+    <Item Id="1735" Name="灵魂蛋糕" />
+    <Item Id="1736" Name="护士帽" Head="113" />
+    <Item Id="1737" Name="护士衣" Body="76" />
+    <Item Id="1738" Name="护士裤" Legs="65" />
+    <Item Id="1739" Name="巫师帽" Head="114" />
+    <Item Id="1740" Name="盖伊·福克斯面具" Head="115" />
+    <Item Id="1741" Name="染料商长袍" Body="77" />
+    <Item Id="1742" Name="蒸汽朋克护目镜" Head="116" />
+    <Item Id="1743" Name="机器侠头盔" Head="117" />
+    <Item Id="1744" Name="机器侠衣" Body="78" />
+    <Item Id="1745" Name="机器侠裤" Legs="66" />
+    <Item Id="1746" Name="苦力怕面具" Head="118" />
+    <Item Id="1747" Name="苦力怕衣" Body="79" />
+    <Item Id="1748" Name="苦力怕裤" Legs="67" />
+    <Item Id="1749" Name="猫咪面具" Head="119" />
+    <Item Id="1750" Name="猫咪衣" Body="80" />
+    <Item Id="1751" Name="猫咪裤" Legs="68" />
+    <Item Id="1752" Name="鬼魂面具" Head="120" />
+    <Item Id="1753" Name="鬼魂衣" Body="81" />
+    <Item Id="1754" Name="南瓜面具" Head="121" />
+    <Item Id="1755" Name="南瓜衣" Body="82" />
+    <Item Id="1756" Name="南瓜裤" Legs="69" />
+    <Item Id="1757" Name="机器人面具" Head="122" />
+    <Item Id="1758" Name="机器人衣" Body="83" />
+    <Item Id="1759" Name="机器人裤" Legs="70" />
+    <Item Id="1760" Name="独角兽面具" Head="123" />
+    <Item Id="1761" Name="独角兽衣" Body="84" />
+    <Item Id="1762" Name="独角兽裤" Legs="71" />
+    <Item Id="1763" Name="吸血鬼面具" Head="124" />
+    <Item Id="1764" Name="吸血鬼衣" Body="85" />
+    <Item Id="1765" Name="吸血鬼裤" Legs="72" />
+    <Item Id="1766" Name="女巫帽" Head="125" />
+    <Item Id="1767" Name="矮妖帽" Head="126" />
+    <Item Id="1768" Name="矮妖衣" Body="86" />
+    <Item Id="1769" Name="矮妖裤" Legs="73" />
+    <Item Id="1770" Name="妖精衣" Body="87" />
+    <Item Id="1771" Name="妖精裤" Legs="74" />
+    <Item Id="1772" Name="公主帽" Head="127" />
+    <Item Id="1773" Name="公主裙" Body="88" />
+    <Item Id="1774" Name="礼袋" />
+    <Item Id="1775" Name="女巫服" Body="89" />
+    <Item Id="1776" Name="女巫靴" Legs="75" />
+    <Item Id="1777" Name="科学怪人新娘面具" Head="128" />
+    <Item Id="1778" Name="科学怪人新娘服" Body="90" />
+    <Item Id="1779" Name="空手道陆龟面具" Head="129" />
+    <Item Id="1780" Name="空手道陆龟衣" Body="91" />
+    <Item Id="1781" Name="空手道陆龟裤" Legs="76" />
+    <Item Id="1782" Name="玉米糖步枪" Rack="true" />
+    <Item Id="1783" Name="玉米糖" Rack="true" />
+    <Item Id="1784" Name="杰克南瓜灯发射器" Rack="true" />
+    <Item Id="1785" Name="爆炸杰克南瓜灯" Rack="true" />
+    <Item Id="1786" Name="镰刀" Rack="true" />
+    <Item Id="1787" Name="南瓜饼" />
+    <Item Id="1788" Name="稻草人帽" Head="130" />
+    <Item Id="1789" Name="稻草人衣" Body="92" />
+    <Item Id="1790" Name="稻草人裤" Legs="77" />
+    <Item Id="1791" Name="大锅" />
+    <Item Id="1792" Name="南瓜椅" />
+    <Item Id="1793" Name="南瓜门" />
+    <Item Id="1794" Name="南瓜桌" />
+    <Item Id="1795" Name="南瓜工作台" />
+    <Item Id="1796" Name="南瓜平台" />
+    <Item Id="1797" Name="褴褛仙灵之翼" />
+    <Item Id="1798" Name="蜘蛛卵" />
+    <Item Id="1799" Name="魔法南瓜子" />
+    <Item Id="1800" Name="蝙蝠钩" />
+    <Item Id="1801" Name="蝙蝠权杖" Rack="true" />
+    <Item Id="1802" Name="乌鸦法杖" />
+    <Item Id="1803" Name="丛林钥匙模具" />
+    <Item Id="1804" Name="腐化钥匙模具" />
+    <Item Id="1805" Name="猩红钥匙模具" />
+    <Item Id="1806" Name="神圣钥匙模具" />
+    <Item Id="1807" Name="冰冻钥匙模具" />
+    <Item Id="1808" Name="杰克南瓜挂灯" />
+    <Item Id="1809" Name="臭蛋" Rack="true" />
+    <Item Id="1810" Name="霉运纱线" />
+    <Item Id="1811" Name="黑色仙尘" />
+    <Item Id="1812" Name="南瓜头吊灯" />
+    <Item Id="1813" Name="杰克南瓜灯" />
+    <Item Id="1814" Name="阴森椅" />
+    <Item Id="1815" Name="阴森门" />
+    <Item Id="1816" Name="阴森桌" />
+    <Item Id="1817" Name="阴森工作台" />
+    <Item Id="1818" Name="阴森平台" />
+    <Item Id="1819" Name="死神兜帽" Head="131" />
+    <Item Id="1820" Name="死神长袍" Body="93" />
+    <Item Id="1821" Name="狐狸面具" Head="132" />
+    <Item Id="1822" Name="狐狸衣" Body="94" />
+    <Item Id="1823" Name="狐狸裤" Legs="78" />
+    <Item Id="1824" Name="猫耳" Head="133" />
+    <Item Id="1825" Name="血腥砍刀" Rack="true" />
+    <Item Id="1826" Name="无头骑士剑" Scale="1.15" Rack="true" />
+    <Item Id="1827" Name="利刃手套" Scale="1.35" Rack="true" />
+    <Item Id="1828" Name="南瓜子" />
+    <Item Id="1829" Name="阴森钩" />
+    <Item Id="1830" Name="阴森之翼" />
+    <Item Id="1831" Name="阴森嫩枝" />
+    <Item Id="1832" Name="阴森头盔" Head="134" />
+    <Item Id="1833" Name="阴森胸甲" Body="95" />
+    <Item Id="1834" Name="阴森护腿" Legs="79" />
+    <Item Id="1835" Name="尖桩发射器" Rack="true" />
+    <Item Id="1836" Name="尖桩" Rack="true" />
+    <Item Id="1837" Name="诅咒树苗" />
+    <Item Id="1838" Name="太空生物面具" Head="135" />
+    <Item Id="1839" Name="太空生物衣" Body="96" />
+    <Item Id="1840" Name="太空生物裤" Legs="80" />
+    <Item Id="1841" Name="狼面具" Head="136" />
+    <Item Id="1842" Name="狼衣" Body="97" />
+    <Item Id="1843" Name="狼裤" Legs="81" />
+    <Item Id="1844" Name="南瓜月勋章" />
+    <Item Id="1845" Name="死灵卷轴" />
+    <Item Id="1846" Name="骷髅夜惊魂" />
+    <Item Id="1847" Name="苦涩收获" />
+    <Item Id="1848" Name="血月伯爵夫人" />
+    <Item Id="1849" Name="万圣节前夕" />
+    <Item Id="1850" Name="病态好奇心" />
+    <Item Id="1851" Name="寻宝人衣" Body="98" />
+    <Item Id="1852" Name="寻宝人裤" Legs="82" />
+    <Item Id="1853" Name="树妖遮体服" Body="99" />
+    <Item Id="1854" Name="树妖腰布" Legs="83" />
+    <Item Id="1855" Name="哀木纪念章" />
+    <Item Id="1856" Name="南瓜王纪念章" />
+    <Item Id="1857" Name="杰克南瓜灯面具" Head="137" />
+    <Item Id="1858" Name="狙击镜" />
+    <Item Id="1859" Name="红心灯笼" />
+    <Item Id="1860" Name="水母潜水装备" />
+    <Item Id="1861" Name="北极潜水装备" />
+    <Item Id="1862" Name="霜花靴" />
+    <Item Id="1863" Name="臭屁气球" />
+    <Item Id="1864" Name="甲虫莎草纸" />
+    <Item Id="1865" Name="天界石" />
+    <Item Id="1866" Name="悬浮板" />
+    <Item Id="1867" Name="糖棒" />
+    <Item Id="1868" Name="蜜糖李" />
+    <Item Id="1869" Name="礼物" />
+    <Item Id="1870" Name="红莱德枪" Rack="true" />
+    <Item Id="1871" Name="喜庆之翼" />
+    <Item Id="1872" Name="松树块" />
+    <Item Id="1873" Name="圣诞树" />
+    <Item Id="1874" Name="星星礼帽1" />
+    <Item Id="1875" Name="星星礼帽2" />
+    <Item Id="1876" Name="星星礼帽3" />
+    <Item Id="1877" Name="蝴蝶结礼帽" />
+    <Item Id="1878" Name="白花环" />
+    <Item Id="1879" Name="白红花环" />
+    <Item Id="1880" Name="红花环" />
+    <Item Id="1881" Name="红绿花环" />
+    <Item Id="1882" Name="绿花环" />
+    <Item Id="1883" Name="绿白花环" />
+    <Item Id="1884" Name="五彩灯泡" />
+    <Item Id="1885" Name="红灯泡" />
+    <Item Id="1886" Name="黄灯泡" />
+    <Item Id="1887" Name="绿灯泡" />
+    <Item Id="1888" Name="红绿灯泡" />
+    <Item Id="1889" Name="黄绿灯泡" />
+    <Item Id="1890" Name="红黄灯泡" />
+    <Item Id="1891" Name="白灯泡" />
+    <Item Id="1892" Name="白红灯泡" />
+    <Item Id="1893" Name="白黄灯泡" />
+    <Item Id="1894" Name="白绿灯泡" />
+    <Item Id="1895" Name="五彩光" />
+    <Item Id="1896" Name="红光" />
+    <Item Id="1897" Name="绿光" />
+    <Item Id="1898" Name="蓝光" />
+    <Item Id="1899" Name="黄光" />
+    <Item Id="1900" Name="红黄光" />
+    <Item Id="1901" Name="红绿光" />
+    <Item Id="1902" Name="黄绿光" />
+    <Item Id="1903" Name="蓝绿光" />
+    <Item Id="1904" Name="红蓝光" />
+    <Item Id="1905" Name="蓝黄光" />
+    <Item Id="1906" Name="巨型蝴蝶结" Head="138" />
+    <Item Id="1907" Name="驯鹿角" Head="139" />
+    <Item Id="1908" Name="冬青树" />
+    <Item Id="1909" Name="糖棒剑" Scale="1.1" Rack="true" />
+    <Item Id="1910" Name="精灵熔炉" Rack="true" />
+    <Item Id="1911" Name="圣诞布丁" />
+    <Item Id="1912" Name="蛋酒" />
+    <Item Id="1913" Name="星形茴香" Rack="true" />
+    <Item Id="1914" Name="驯鹿铃铛" />
+    <Item Id="1915" Name="糖棒钩" />
+    <Item Id="1916" Name="圣诞钩" />
+    <Item Id="1917" Name="糖棒镐" Rack="true" />
+    <Item Id="1918" Name="水果蛋糕旋刃" Rack="true" />
+    <Item Id="1919" Name="蜜糖饼干" />
+    <Item Id="1920" Name="姜饼" />
+    <Item Id="1921" Name="暖手宝" />
+    <Item Id="1922" Name="煤" />
+    <Item Id="1923" Name="工具箱" />
+    <Item Id="1924" Name="松树门" />
+    <Item Id="1925" Name="松树椅" />
+    <Item Id="1926" Name="松树桌" />
+    <Item Id="1927" Name="狗哨" />
+    <Item Id="1928" Name="圣诞树剑" Scale="1.1" Rack="true" />
+    <Item Id="1929" Name="链式机枪" Rack="true" />
+    <Item Id="1930" Name="剃刀松" Rack="true" />
+    <Item Id="1931" Name="暴雪法杖" Rack="true" />
+    <Item Id="1932" Name="圣诞夫人帽" Head="140" />
+    <Item Id="1933" Name="圣诞夫人衣" Body="100" />
+    <Item Id="1934" Name="圣诞夫人高跟鞋" Legs="84" />
+    <Item Id="1935" Name="派克兜帽" Head="142" />
+    <Item Id="1936" Name="派克大衣" Body="102" />
+    <Item Id="1937" Name="派克裤" Legs="86" />
+    <Item Id="1938" Name="雪帽" Head="143" />
+    <Item Id="1939" Name="丑毛衣" Body="103" />
+    <Item Id="1940" Name="树面具" Head="141" />
+    <Item Id="1941" Name="树衣" Body="101" />
+    <Item Id="1942" Name="树干" Legs="85" />
+    <Item Id="1943" Name="精灵帽" Head="144" />
+    <Item Id="1944" Name="精灵衣" Body="104" />
+    <Item Id="1945" Name="精灵裤" Legs="87" />
+    <Item Id="1946" Name="雪人炮" Rack="true" />
+    <Item Id="1947" Name="北极" Scale="1.1" Rack="true" />
+    <Item Id="1948" Name="圣诞树壁纸" />
+    <Item Id="1949" Name="装饰壁纸" />
+    <Item Id="1950" Name="糖棒壁纸" />
+    <Item Id="1951" Name="节日壁纸" />
+    <Item Id="1952" Name="星星壁纸" />
+    <Item Id="1953" Name="波浪条纹壁纸" />
+    <Item Id="1954" Name="雪花壁纸" />
+    <Item Id="1955" Name="坎卜斯犄角壁纸" />
+    <Item Id="1956" Name="蓝绿壁纸" />
+    <Item Id="1957" Name="格林奇手指壁纸" />
+    <Item Id="1958" Name="调皮礼物" />
+    <Item Id="1959" Name="格林奇宝宝的恶作剧口哨" />
+    <Item Id="1960" Name="冰雪女王纪念章" />
+    <Item Id="1961" Name="圣诞坦克纪念章" />
+    <Item Id="1962" Name="常绿尖叫怪纪念章" />
+    <Item Id="1963" Name="八音盒（南瓜月）" />
+    <Item Id="1964" Name="八音盒（地下备选曲）" />
+    <Item Id="1965" Name="八音盒（霜月）" />
+    <Item Id="1966" Name="棕漆" />
+    <Item Id="1967" Name="暗影漆" />
+    <Item Id="1968" Name="反色漆" />
+    <Item Id="1969" Name="团队染料" />
+    <Item Id="1970" Name="紫晶晶莹宝石块" />
+    <Item Id="1971" Name="黄玉晶莹宝石块" />
+    <Item Id="1972" Name="蓝玉晶莹宝石块" />
+    <Item Id="1973" Name="翡翠晶莹宝石块" />
+    <Item Id="1974" Name="红玉晶莹宝石块" />
+    <Item Id="1975" Name="钻石晶莹宝石块" />
+    <Item Id="1976" Name="琥珀晶莹宝石块" />
+    <Item Id="1977" Name="生命染发剂" />
+    <Item Id="1978" Name="魔力染发剂" />
+    <Item Id="1979" Name="深度染发剂" />
+    <Item Id="1980" Name="钱币染发剂" />
+    <Item Id="1981" Name="时间染发剂" />
+    <Item Id="1982" Name="团队染发剂" />
+    <Item Id="1983" Name="生物群落染发剂" />
+    <Item Id="1984" Name="派对染发剂" />
+    <Item Id="1985" Name="彩虹染发剂" />
+    <Item Id="1986" Name="速度染发剂" />
+    <Item Id="1987" Name="天使光环" />
+    <Item Id="1988" Name="菲斯帽" Head="145" />
+    <Item Id="1989" Name="女模特" />
+    <Item Id="1990" Name="染发剂清除剂" />
+    <Item Id="1991" Name="虫网" />
+    <Item Id="1992" Name="萤火虫" />
+    <Item Id="1993" Name="萤火虫瓶" />
+    <Item Id="1994" Name="帝王蝶" />
+    <Item Id="1995" Name="紫君王蝶" />
+    <Item Id="1996" Name="红纹蝶" />
+    <Item Id="1997" Name="尤利西斯蝶" />
+    <Item Id="1998" Name="硫磺蝶" />
+    <Item Id="1999" Name="树若虫蝴蝶" />
+    <Item Id="2000" Name="斑纹燕尾蝶" />
+    <Item Id="2001" Name="茱莉娅蝶" />
+    <Item Id="2002" Name="蠕虫" />
+    <Item Id="2003" Name="老鼠" />
+    <Item Id="2004" Name="荧光虫" />
+    <Item Id="2005" Name="荧光虫瓶" />
+    <Item Id="2006" Name="蜗牛" />
+    <Item Id="2007" Name="发光蜗牛" />
+    <Item Id="2008" Name="别致灰壁纸" />
+    <Item Id="2009" Name="浮冰壁纸" />
+    <Item Id="2010" Name="音符壁纸" />
+    <Item Id="2011" Name="紫雨壁纸" />
+    <Item Id="2012" Name="彩虹壁纸" />
+    <Item Id="2013" Name="烁石壁纸" />
+    <Item Id="2014" Name="星光天堂壁纸" />
+    <Item Id="2015" Name="鸟" />
+    <Item Id="2016" Name="冠蓝鸦" />
+    <Item Id="2017" Name="红雀" />
+    <Item Id="2018" Name="松鼠" />
+    <Item Id="2019" Name="兔兔" />
+    <Item Id="2020" Name="仙人掌书架" />
+    <Item Id="2021" Name="乌木书架" />
+    <Item Id="2022" Name="血肉书架" />
+    <Item Id="2023" Name="蜂蜜书架" />
+    <Item Id="2024" Name="蒸汽朋克书架" />
+    <Item Id="2025" Name="玻璃书架" />
+    <Item Id="2026" Name="红木书架" />
+    <Item Id="2027" Name="珍珠木书架" />
+    <Item Id="2028" Name="阴森书架" />
+    <Item Id="2029" Name="天域书架" />
+    <Item Id="2030" Name="丛林蜥蜴书架" />
+    <Item Id="2031" Name="冰冻书架" />
+    <Item Id="2032" Name="仙人掌灯笼" />
+    <Item Id="2033" Name="乌木灯笼" />
+    <Item Id="2034" Name="血肉灯笼" />
+    <Item Id="2035" Name="蜂蜜灯笼" />
+    <Item Id="2036" Name="蒸汽朋克灯笼" />
+    <Item Id="2037" Name="玻璃灯笼" />
+    <Item Id="2038" Name="红木灯笼" />
+    <Item Id="2039" Name="珍珠木灯笼" />
+    <Item Id="2040" Name="冰冻灯笼" />
+    <Item Id="2041" Name="丛林蜥蜴灯笼" />
+    <Item Id="2042" Name="天域灯笼" />
+    <Item Id="2043" Name="阴森灯笼" />
+    <Item Id="2044" Name="冰冻门" />
+    <Item Id="2045" Name="仙人掌蜡烛" />
+    <Item Id="2046" Name="乌木蜡烛" />
+    <Item Id="2047" Name="血肉蜡烛" />
+    <Item Id="2048" Name="玻璃蜡烛" />
+    <Item Id="2049" Name="冰冻蜡烛" />
+    <Item Id="2050" Name="红木蜡烛" />
+    <Item Id="2051" Name="珍珠木蜡烛" />
+    <Item Id="2052" Name="丛林蜥蜴蜡烛" />
+    <Item Id="2053" Name="天域蜡烛" />
+    <Item Id="2054" Name="南瓜蜡烛" />
+    <Item Id="2055" Name="仙人掌吊灯" />
+    <Item Id="2056" Name="乌木吊灯" />
+    <Item Id="2057" Name="血肉吊灯" />
+    <Item Id="2058" Name="蜂蜜吊灯" />
+    <Item Id="2059" Name="冰冻吊灯" />
+    <Item Id="2060" Name="红木吊灯" />
+    <Item Id="2061" Name="珍珠木吊灯" />
+    <Item Id="2062" Name="丛林蜥蜴吊灯" />
+    <Item Id="2063" Name="天域吊灯" />
+    <Item Id="2064" Name="阴森吊灯" />
+    <Item Id="2065" Name="玻璃吊灯" />
+    <Item Id="2066" Name="仙人掌床" />
+    <Item Id="2067" Name="血肉床" />
+    <Item Id="2068" Name="冰冻床" />
+    <Item Id="2069" Name="丛林蜥蜴床" />
+    <Item Id="2070" Name="天域床" />
+    <Item Id="2071" Name="阴森床" />
+    <Item Id="2072" Name="仙人掌浴缸" />
+    <Item Id="2073" Name="乌木浴缸" />
+    <Item Id="2074" Name="血肉浴缸" />
+    <Item Id="2075" Name="玻璃浴缸" />
+    <Item Id="2076" Name="冰冻浴缸" />
+    <Item Id="2077" Name="红木浴缸" />
+    <Item Id="2078" Name="珍珠木浴缸" />
+    <Item Id="2079" Name="丛林蜥蜴浴缸" />
+    <Item Id="2080" Name="天域浴缸" />
+    <Item Id="2081" Name="阴森浴缸" />
+    <Item Id="2082" Name="仙人掌灯" />
+    <Item Id="2083" Name="乌木灯" />
+    <Item Id="2084" Name="血肉灯" />
+    <Item Id="2085" Name="玻璃灯" />
+    <Item Id="2086" Name="冰冻灯" />
+    <Item Id="2087" Name="红木灯" />
+    <Item Id="2088" Name="珍珠木灯" />
+    <Item Id="2089" Name="丛林蜥蜴灯" />
+    <Item Id="2090" Name="天域灯" />
+    <Item Id="2091" Name="阴森灯" />
+    <Item Id="2092" Name="仙人掌烛台" />
+    <Item Id="2093" Name="乌木烛台" />
+    <Item Id="2094" Name="血肉烛台" />
+    <Item Id="2095" Name="蜂蜜烛台" />
+    <Item Id="2096" Name="蒸汽朋克烛台" />
+    <Item Id="2097" Name="玻璃烛台" />
+    <Item Id="2098" Name="红木大烛台" />
+    <Item Id="2099" Name="珍珠木烛台" />
+    <Item Id="2100" Name="冰冻烛台" />
+    <Item Id="2101" Name="丛林蜥蜴烛台" />
+    <Item Id="2102" Name="天域烛台" />
+    <Item Id="2103" Name="阴森大烛台" />
+    <Item Id="2104" Name="克苏鲁之脑面具" Head="146" />
+    <Item Id="2105" Name="血肉墙面具" Head="147" />
+    <Item Id="2106" Name="双子魔眼面具" Head="148" />
+    <Item Id="2107" Name="机械骷髅王面具" Head="149" />
+    <Item Id="2108" Name="蜂王面具" Head="150" />
+    <Item Id="2109" Name="世纪之花面具" Head="151" />
+    <Item Id="2110" Name="石巨人面具" Head="152" />
+    <Item Id="2111" Name="世界吞噬怪面具" Head="153" />
+    <Item Id="2112" Name="克苏鲁之眼面具" Head="154" />
+    <Item Id="2113" Name="毁灭者面具" Head="155" />
+    <Item Id="2114" Name="铁匠架" />
+    <Item Id="2115" Name="木工架" />
+    <Item Id="2116" Name="头盔架" />
+    <Item Id="2117" Name="长矛架" />
+    <Item Id="2118" Name="剑架" />
+    <Item Id="2119" Name="石板" />
+    <Item Id="2120" Name="沙岩板" />
+    <Item Id="2121" Name="青蛙" />
+    <Item Id="2122" Name="野鸭" />
+    <Item Id="2123" Name="鸭" />
+    <Item Id="2124" Name="蜂蜜浴缸" />
+    <Item Id="2125" Name="蒸汽朋克浴缸" />
+    <Item Id="2126" Name="生命木浴缸" />
+    <Item Id="2127" Name="暗影木浴缸" />
+    <Item Id="2128" Name="骨头浴缸" />
+    <Item Id="2129" Name="蜂蜜灯" />
+    <Item Id="2130" Name="蒸汽朋克灯" />
+    <Item Id="2131" Name="生命木灯" />
+    <Item Id="2132" Name="暗影木灯" />
+    <Item Id="2133" Name="金灯" />
+    <Item Id="2134" Name="骨头灯" />
+    <Item Id="2135" Name="生命木书架" />
+    <Item Id="2136" Name="暗影木书架" />
+    <Item Id="2137" Name="金书架" />
+    <Item Id="2138" Name="骨头书架" />
+    <Item Id="2139" Name="生命木床" />
+    <Item Id="2140" Name="骨头床" />
+    <Item Id="2141" Name="生命木吊灯" />
+    <Item Id="2142" Name="暗影木吊灯" />
+    <Item Id="2143" Name="金制吊灯" />
+    <Item Id="2144" Name="骨头吊灯" />
+    <Item Id="2145" Name="生命木灯笼" />
+    <Item Id="2146" Name="暗影木灯笼" />
+    <Item Id="2147" Name="金灯笼" />
+    <Item Id="2148" Name="骨头灯笼" />
+    <Item Id="2149" Name="生命木烛台" />
+    <Item Id="2150" Name="暗影木烛台" />
+    <Item Id="2151" Name="金烛台" />
+    <Item Id="2152" Name="骨头烛台" />
+    <Item Id="2153" Name="生命木蜡烛" />
+    <Item Id="2154" Name="暗影木蜡烛" />
+    <Item Id="2155" Name="金蜡烛" />
+    <Item Id="2156" Name="黑蝎子" />
+    <Item Id="2157" Name="蝎子" />
+    <Item Id="2158" Name="泡泡壁纸" />
+    <Item Id="2159" Name="铜管壁纸" />
+    <Item Id="2160" Name="黄鸭壁纸" />
+    <Item Id="2161" Name="寒霜核" />
+    <Item Id="2162" Name="兔兔笼" />
+    <Item Id="2163" Name="松鼠笼" />
+    <Item Id="2164" Name="野鸭笼" />
+    <Item Id="2165" Name="鸭笼" />
+    <Item Id="2166" Name="鸟笼" />
+    <Item Id="2167" Name="冠蓝鸦笼" />
+    <Item Id="2168" Name="红雀笼" />
+    <Item Id="2169" Name="瀑布墙" />
+    <Item Id="2170" Name="熔岩瀑布墙" />
+    <Item Id="2171" Name="猩红种子" />
+    <Item Id="2172" Name="重型工作台" />
+    <Item Id="2173" Name="铜镀层" />
+    <Item Id="2174" Name="蜗牛笼" />
+    <Item Id="2175" Name="发光蜗牛笼" />
+    <Item Id="2176" Name="蘑菇矿挖爪" Rack="true" />
+    <Item Id="2177" Name="弹药箱" />
+    <Item Id="2178" Name="帝王蝶罐" />
+    <Item Id="2179" Name="紫君王蝶罐" />
+    <Item Id="2180" Name="红纹蝶罐" />
+    <Item Id="2181" Name="尤利西斯蝶罐" />
+    <Item Id="2182" Name="硫磺蝶罐" />
+    <Item Id="2183" Name="树若虫蝴蝶罐" />
+    <Item Id="2184" Name="斑纹燕尾蝶罐" />
+    <Item Id="2185" Name="茱莉娅蝶罐" />
+    <Item Id="2186" Name="蝎子笼" />
+    <Item Id="2187" Name="黑蝎子笼" />
+    <Item Id="2188" Name="毒液法杖" Rack="true" />
+    <Item Id="2189" Name="幽灵面具" Head="156" />
+    <Item Id="2190" Name="蛙笼" />
+    <Item Id="2191" Name="老鼠笼" />
+    <Item Id="2192" Name="骨头焊机" />
+    <Item Id="2193" Name="血肉克隆台" />
+    <Item Id="2194" Name="玻璃窑" />
+    <Item Id="2195" Name="丛林蜥蜴熔炉" />
+    <Item Id="2196" Name="生命木织机" />
+    <Item Id="2197" Name="天磨" />
+    <Item Id="2198" Name="冰雪机" />
+    <Item Id="2199" Name="甲虫头盔" Head="157" />
+    <Item Id="2200" Name="甲虫铠甲" Body="105" />
+    <Item Id="2201" Name="甲虫壳" Body="106" />
+    <Item Id="2202" Name="甲虫护腿" Legs="98" />
+    <Item Id="2203" Name="蒸汽朋克锅炉" />
+    <Item Id="2204" Name="蜂蜜分配机" />
+    <Item Id="2205" Name="企鹅" />
+    <Item Id="2206" Name="企鹅笼" />
+    <Item Id="2207" Name="蠕虫笼" />
+    <Item Id="2208" Name="泰拉制笼机" />
+    <Item Id="2209" Name="超级魔力药水" />
+    <Item Id="2210" Name="乌木栅栏" />
+    <Item Id="2211" Name="红木栅栏" />
+    <Item Id="2212" Name="珍珠木栅栏" />
+    <Item Id="2213" Name="暗影木栅栏" />
+    <Item Id="2214" Name="砖层" />
+    <Item Id="2215" Name="加长握爪" />
+    <Item Id="2216" Name="喷漆器" />
+    <Item Id="2217" Name="便携式水泥搅拌机" />
+    <Item Id="2218" Name="甲虫外壳" />
+    <Item Id="2219" Name="天界磁石" />
+    <Item Id="2220" Name="天界徽章" />
+    <Item Id="2221" Name="天界手铐" />
+    <Item Id="2222" Name="商贩帽" Head="158" />
+    <Item Id="2223" Name="脉冲弓" Rack="true" />
+    <Item Id="2224" Name="大王朝灯笼" />
+    <Item Id="2225" Name="王朝灯" />
+    <Item Id="2226" Name="王朝灯笼" />
+    <Item Id="2227" Name="大王朝蜡烛" />
+    <Item Id="2228" Name="王朝椅" />
+    <Item Id="2229" Name="王朝工作台" />
+    <Item Id="2230" Name="王朝箱" />
+    <Item Id="2231" Name="王朝床" />
+    <Item Id="2232" Name="王朝浴缸" />
+    <Item Id="2233" Name="王朝书架" />
+    <Item Id="2234" Name="王朝杯" />
+    <Item Id="2235" Name="王朝碗" />
+    <Item Id="2236" Name="王朝蜡烛" />
+    <Item Id="2237" Name="王朝时钟" />
+    <Item Id="2238" Name="金时钟" />
+    <Item Id="2239" Name="玻璃时钟" />
+    <Item Id="2240" Name="蜂蜜时钟" />
+    <Item Id="2241" Name="蒸汽朋克时钟" />
+    <Item Id="2242" Name="精致餐具" />
+    <Item Id="2243" Name="玻璃碗" />
+    <Item Id="2244" Name="葡萄酒杯" />
+    <Item Id="2245" Name="生命木钢琴" />
+    <Item Id="2246" Name="血肉钢琴" />
+    <Item Id="2247" Name="冰冻钢琴" />
+    <Item Id="2248" Name="冰冻桌" />
+    <Item Id="2249" Name="蜂蜜箱" />
+    <Item Id="2250" Name="蒸汽朋克箱" />
+    <Item Id="2251" Name="蜂蜜工作台" />
+    <Item Id="2252" Name="冰冻工作台" />
+    <Item Id="2253" Name="蒸汽朋克工作台" />
+    <Item Id="2254" Name="玻璃钢琴" />
+    <Item Id="2255" Name="蜂蜜钢琴" />
+    <Item Id="2256" Name="蒸汽朋克钢琴" />
+    <Item Id="2257" Name="蜂蜜杯" />
+    <Item Id="2258" Name="圣餐杯" />
+    <Item Id="2259" Name="王朝桌" />
+    <Item Id="2260" Name="王朝木" />
+    <Item Id="2261" Name="红王朝瓦" />
+    <Item Id="2262" Name="蓝王朝瓦" />
+    <Item Id="2263" Name="白王朝墙" />
+    <Item Id="2264" Name="蓝王朝墙" />
+    <Item Id="2265" Name="王朝门" />
+    <Item Id="2266" Name="清酒" />
+    <Item Id="2267" Name="泰式炒面" />
+    <Item Id="2268" Name="越南河粉" />
+    <Item Id="2269" Name="左轮手枪" Scale="0.85" Rack="true" />
+    <Item Id="2270" Name="鳄鱼机关枪" Rack="true" />
+    <Item Id="2271" Name="奥术神符墙" />
+    <Item Id="2272" Name="水枪" Scale="0.9" />
+    <Item Id="2273" Name="武士刀" Rack="true" />
+    <Item Id="2274" Name="超亮火把" />
+    <Item Id="2275" Name="魔法帽" Head="159" />
+    <Item Id="2276" Name="钻石戒指" />
+    <Item Id="2277" Name="稽古衣" Body="165" />
+    <Item Id="2278" Name="和服" Body="166" />
+    <Item Id="2279" Name="吉普赛长袍" Body="167" />
+    <Item Id="2280" Name="甲虫之翼" />
+    <Item Id="2281" Name="虎皮" />
+    <Item Id="2282" Name="豹皮" />
+    <Item Id="2283" Name="斑马皮" />
+    <Item Id="2284" Name="猩红斗篷" />
+    <Item Id="2285" Name="神秘披风" />
+    <Item Id="2286" Name="红披风" />
+    <Item Id="2287" Name="冬季披风" />
+    <Item Id="2288" Name="冰冻椅" />
+    <Item Id="2289" Name="木钓竿" Rack="true" />
+    <Item Id="2290" Name="鲈鱼" />
+    <Item Id="2291" Name="强化钓竿" Rack="true" />
+    <Item Id="2292" Name="玻璃钢钓竿" Rack="true" />
+    <Item Id="2293" Name="灵魂钓手" Rack="true" />
+    <Item Id="2294" Name="金钓竿" Rack="true" />
+    <Item Id="2295" Name="机械师钓竿" Rack="true" />
+    <Item Id="2296" Name="冤大头钓竿" Rack="true" />
+    <Item Id="2297" Name="鳟鱼" />
+    <Item Id="2298" Name="三文鱼" />
+    <Item Id="2299" Name="大西洋鳕鱼" />
+    <Item Id="2300" Name="金枪鱼" />
+    <Item Id="2301" Name="红鲷鱼" />
+    <Item Id="2302" Name="霓虹脂鲤" />
+    <Item Id="2303" Name="装甲洞穴鱼" />
+    <Item Id="2304" Name="雀鲷" />
+    <Item Id="2305" Name="猩红虎鱼" />
+    <Item Id="2306" Name="寒霜鲦鱼" />
+    <Item Id="2307" Name="公主鱼" />
+    <Item Id="2308" Name="金鲤鱼" />
+    <Item Id="2309" Name="镜面鱼" />
+    <Item Id="2310" Name="七彩矿鱼" />
+    <Item Id="2311" Name="斑驳油鱼" />
+    <Item Id="2312" Name="闪鳍锦鲤" />
+    <Item Id="2313" Name="双鳍鳕鱼" />
+    <Item Id="2314" Name="蜂蜜鱼" />
+    <Item Id="2315" Name="黑曜石鱼" />
+    <Item Id="2316" Name="虾" />
+    <Item Id="2317" Name="混沌鱼" />
+    <Item Id="2318" Name="黑檀锦鲤" />
+    <Item Id="2319" Name="血腥食人鱼" />
+    <Item Id="2320" Name="岩鱼锤" Scale="1.05" Rack="true" />
+    <Item Id="2321" Name="臭味鱼" />
+    <Item Id="2322" Name="挖矿药水" />
+    <Item Id="2323" Name="拾心药水" />
+    <Item Id="2324" Name="镇静药水" />
+    <Item Id="2325" Name="建筑工药水" />
+    <Item Id="2326" Name="泰坦药水" />
+    <Item Id="2327" Name="脚蹼药水" />
+    <Item Id="2328" Name="召唤药水" />
+    <Item Id="2329" Name="危险感药水" />
+    <Item Id="2330" Name="紫挥棒鱼" Scale="1.15" Rack="true" />
+    <Item Id="2331" Name="黑曜石剑鱼" Rack="true" />
+    <Item Id="2332" Name="剑鱼" Rack="true" />
+    <Item Id="2333" Name="铁栅栏" />
+    <Item Id="2334" Name="木匣" />
+    <Item Id="2335" Name="铁匣" />
+    <Item Id="2336" Name="金匣" />
+    <Item Id="2337" Name="旧鞋" />
+    <Item Id="2338" Name="海草" />
+    <Item Id="2339" Name="锡罐" />
+    <Item Id="2340" Name="矿车轨道" />
+    <Item Id="2341" Name="掠夺鲨" Scale="1.15" Rack="true" />
+    <Item Id="2342" Name="锯齿鲨" Rack="true" />
+    <Item Id="2343" Name="矿车" />
+    <Item Id="2344" Name="弹药储备药水" />
+    <Item Id="2345" Name="生命力药水" />
+    <Item Id="2346" Name="耐力药水" />
+    <Item Id="2347" Name="暴怒药水" />
+    <Item Id="2348" Name="狱火药水" />
+    <Item Id="2349" Name="怒气药水" />
+    <Item Id="2350" Name="回忆药水" />
+    <Item Id="2351" Name="传送药水" />
+    <Item Id="2352" Name="爱情药水" />
+    <Item Id="2353" Name="臭味药水" />
+    <Item Id="2354" Name="钓鱼药水" />
+    <Item Id="2355" Name="声纳药水" />
+    <Item Id="2356" Name="宝匣药水" />
+    <Item Id="2357" Name="寒颤棘种子" />
+    <Item Id="2358" Name="寒颤棘" />
+    <Item Id="2359" Name="保暖药水" />
+    <Item Id="2360" Name="鱼钩" />
+    <Item Id="2361" Name="蜜蜂头饰" Head="160" />
+    <Item Id="2362" Name="蜜蜂胸甲" Body="168" />
+    <Item Id="2363" Name="蜜蜂护胫" Legs="103" />
+    <Item Id="2364" Name="黄蜂法杖" Rack="true" />
+    <Item Id="2365" Name="小鬼法杖" Rack="true" />
+    <Item Id="2366" Name="蜘蛛女王法杖" Rack="true" />
+    <Item Id="2367" Name="渔夫帽" Head="161" />
+    <Item Id="2368" Name="渔夫背心" Body="169" />
+    <Item Id="2369" Name="渔夫裤" Legs="104" />
+    <Item Id="2370" Name="蜘蛛面具" Head="162" />
+    <Item Id="2371" Name="蜘蛛胸甲" Body="170" />
+    <Item Id="2372" Name="蜘蛛护胫" Legs="105" />
+    <Item Id="2373" Name="优质钓鱼线" />
+    <Item Id="2374" Name="渔夫耳环" />
+    <Item Id="2375" Name="钓具箱" />
+    <Item Id="2376" Name="蓝地牢钢琴" />
+    <Item Id="2377" Name="绿地牢钢琴" />
+    <Item Id="2378" Name="粉地牢钢琴" />
+    <Item Id="2379" Name="金钢琴" />
+    <Item Id="2380" Name="黑曜石钢琴" />
+    <Item Id="2381" Name="骨头钢琴" />
+    <Item Id="2382" Name="仙人掌钢琴" />
+    <Item Id="2383" Name="阴森钢琴" />
+    <Item Id="2384" Name="天域钢琴" />
+    <Item Id="2385" Name="丛林蜥蜴钢琴" />
+    <Item Id="2386" Name="蓝地牢梳妆台" />
+    <Item Id="2387" Name="绿地牢梳妆台" />
+    <Item Id="2388" Name="粉地牢梳妆台" />
+    <Item Id="2389" Name="金梳妆台" />
+    <Item Id="2390" Name="黑曜石梳妆台" />
+    <Item Id="2391" Name="骨头梳妆台" />
+    <Item Id="2392" Name="仙人掌梳妆台" />
+    <Item Id="2393" Name="阴森梳妆台" />
+    <Item Id="2394" Name="天域梳妆台" />
+    <Item Id="2395" Name="蜂蜜梳妆台" />
+    <Item Id="2396" Name="丛林蜥蜴梳妆台" />
+    <Item Id="2397" Name="沙发" />
+    <Item Id="2398" Name="乌木沙发" />
+    <Item Id="2399" Name="红木沙发" />
+    <Item Id="2400" Name="珍珠木沙发" />
+    <Item Id="2401" Name="暗影木沙发" />
+    <Item Id="2402" Name="蓝地牢沙发" />
+    <Item Id="2403" Name="绿地牢沙发" />
+    <Item Id="2404" Name="粉地牢沙发" />
+    <Item Id="2405" Name="金沙发" />
+    <Item Id="2406" Name="黑曜石沙发" />
+    <Item Id="2407" Name="骨头沙发" />
+    <Item Id="2408" Name="仙人掌沙发" />
+    <Item Id="2409" Name="阴森沙发" />
+    <Item Id="2410" Name="天域沙发" />
+    <Item Id="2411" Name="蜂蜜沙发" />
+    <Item Id="2412" Name="蒸汽朋克沙发" />
+    <Item Id="2413" Name="蘑菇沙发" />
+    <Item Id="2414" Name="玻璃沙发" />
+    <Item Id="2415" Name="南瓜沙发" />
+    <Item Id="2416" Name="丛林蜥蜴沙发" />
+    <Item Id="2417" Name="贝壳发夹" Head="163" />
+    <Item Id="2418" Name="美人鱼饰品" Body="171" />
+    <Item Id="2419" Name="美人鱼鱼尾裤" Legs="106" />
+    <Item Id="2420" Name="和风鱼" />
+    <Item Id="2421" Name="捕肉手" Rack="true" />
+    <Item Id="2422" Name="熔线钓钩" Rack="true" />
+    <Item Id="2423" Name="蛙腿" />
+    <Item Id="2424" Name="锚" Rack="true" />
+    <Item Id="2425" Name="熟鱼" />
+    <Item Id="2426" Name="熟虾" />
+    <Item Id="2427" Name="生鱼片" />
+    <Item Id="2428" Name="绒毛胡萝卜" />
+    <Item Id="2429" Name="带鳞松露" />
+    <Item Id="2430" Name="粘鞍" />
+    <Item Id="2431" Name="蜂蜡" />
+    <Item Id="2432" Name="镀铜墙" />
+    <Item Id="2433" Name="石板墙" />
+    <Item Id="2434" Name="船帆" />
+    <Item Id="2435" Name="珊瑚石块" />
+    <Item Id="2436" Name="蓝水母" />
+    <Item Id="2437" Name="绿水母" />
+    <Item Id="2438" Name="粉水母" />
+    <Item Id="2439" Name="蓝水母罐" />
+    <Item Id="2440" Name="绿水母罐" />
+    <Item Id="2441" Name="粉水母罐" />
+    <Item Id="2442" Name="救生圈" />
+    <Item Id="2443" Name="舵轮" />
+    <Item Id="2444" Name="罗盘针" />
+    <Item Id="2445" Name="墙锚" />
+    <Item Id="2446" Name="金鱼纪念章" />
+    <Item Id="2447" Name="兔兔鱼纪念章" />
+    <Item Id="2448" Name="剑鱼纪念章" />
+    <Item Id="2449" Name="鲨牙纪念章" />
+    <Item Id="2450" Name="蝙蝠鱼" />
+    <Item Id="2451" Name="大黄蜂金枪鱼" />
+    <Item Id="2452" Name="鲶鱼" />
+    <Item Id="2453" Name="云鱼" />
+    <Item Id="2454" Name="诅咒鱼" />
+    <Item Id="2455" Name="土鱼" />
+    <Item Id="2456" Name="雷管鱼" />
+    <Item Id="2457" Name="浮游噬鱼" />
+    <Item Id="2458" Name="坠落海星" />
+    <Item Id="2459" Name="克苏鲁鱼" />
+    <Item Id="2460" Name="骷髅鱼" />
+    <Item Id="2461" Name="鸟妖鱼" />
+    <Item Id="2462" Name="饥饿鱼" />
+    <Item Id="2463" Name="灵液鱼" />
+    <Item Id="2464" Name="珠宝鱼" />
+    <Item Id="2465" Name="幻影鱼" />
+    <Item Id="2466" Name="突变弗林鱼" />
+    <Item Id="2467" Name="企鹅鱼" />
+    <Item Id="2468" Name="妖精鱼" />
+    <Item Id="2469" Name="蜘蛛鱼" />
+    <Item Id="2470" Name="苔原鳟鱼" />
+    <Item Id="2471" Name="独角兽鱼" />
+    <Item Id="2472" Name="向导巫毒鱼" />
+    <Item Id="2473" Name="飞龙尾" />
+    <Item Id="2474" Name="僵尸鱼" />
+    <Item Id="2475" Name="毒菌鱼" />
+    <Item Id="2476" Name="天使鱼" />
+    <Item Id="2477" Name="血腥战神" />
+    <Item Id="2478" Name="骷髅鱼" />
+    <Item Id="2479" Name="兔兔鱼" />
+    <Item Id="2480" Name="金枪鱼须船长" />
+    <Item Id="2481" Name="小丑鱼" />
+    <Item Id="2482" Name="恶魔地狱鱼" />
+    <Item Id="2483" Name="跳跳鱼" />
+    <Item Id="2484" Name="猪龙鱼" />
+    <Item Id="2485" Name="染病鞘鱼" />
+    <Item Id="2486" Name="泥鱼" />
+    <Item Id="2487" Name="史莱姆鱼" />
+    <Item Id="2488" Name="热带梭鱼" />
+    <Item Id="2489" Name="史莱姆王纪念章" />
+    <Item Id="2490" Name="船舶瓶" />
+    <Item Id="2491" Name="海龟鞍" />
+    <Item Id="2492" Name="压力板轨道" />
+    <Item Id="2493" Name="史莱姆王面具" Head="164" />
+    <Item Id="2494" Name="鳍翼" />
+    <Item Id="2495" Name="宝藏地图" />
+    <Item Id="2496" Name="海草花盆" />
+    <Item Id="2497" Name="海贼像素画" />
+    <Item Id="2498" Name="鱼装面具" Head="165" />
+    <Item Id="2499" Name="鱼装衣" Body="172" />
+    <Item Id="2500" Name="鱼装鳍裙" Legs="107" />
+    <Item Id="2501" Name="姜须" />
+    <Item Id="2502" Name="涂蜜护目镜" />
+    <Item Id="2503" Name="针叶木" />
+    <Item Id="2504" Name="棕榈木" />
+    <Item Id="2505" Name="针叶木墙" />
+    <Item Id="2506" Name="棕榈木墙" />
+    <Item Id="2507" Name="针叶木栅栏" />
+    <Item Id="2508" Name="棕榈木栅栏" />
+    <Item Id="2509" Name="针叶木头盔" Head="166" />
+    <Item Id="2510" Name="针叶木胸甲" Body="173" />
+    <Item Id="2511" Name="针叶木护胫" Legs="108" />
+    <Item Id="2512" Name="棕榈木头盔" Head="167" />
+    <Item Id="2513" Name="棕榈木胸甲" Body="174" />
+    <Item Id="2514" Name="棕榈木护胫" Legs="109" />
+    <Item Id="2515" Name="棕榈木弓" Rack="true" />
+    <Item Id="2516" Name="棕榈木锤" Scale="1.1" Rack="true" />
+    <Item Id="2517" Name="棕榈木剑" Rack="true" />
+    <Item Id="2518" Name="棕榈木平台" />
+    <Item Id="2519" Name="棕榈木浴缸" />
+    <Item Id="2520" Name="棕榈木床" />
+    <Item Id="2521" Name="棕榈木长椅" />
+    <Item Id="2522" Name="棕榈木烛台" />
+    <Item Id="2523" Name="棕榈木蜡烛" />
+    <Item Id="2524" Name="棕榈木椅" />
+    <Item Id="2525" Name="棕榈木吊灯" />
+    <Item Id="2526" Name="棕榈木箱" />
+    <Item Id="2527" Name="棕榈木沙发" />
+    <Item Id="2528" Name="棕榈木门" />
+    <Item Id="2529" Name="棕榈木梳妆台" />
+    <Item Id="2530" Name="棕榈木灯笼" />
+    <Item Id="2531" Name="棕榈木钢琴" />
+    <Item Id="2532" Name="棕榈木桌" />
+    <Item Id="2533" Name="棕榈木灯" />
+    <Item Id="2534" Name="棕榈木工作台" />
+    <Item Id="2535" Name="魔眼法杖" Rack="true" />
+    <Item Id="2536" Name="棕榈木书架" />
+    <Item Id="2537" Name="蘑菇浴缸" />
+    <Item Id="2538" Name="蘑菇床" />
+    <Item Id="2539" Name="蘑菇长椅" />
+    <Item Id="2540" Name="蘑菇书架" />
+    <Item Id="2541" Name="蘑菇烛台" />
+    <Item Id="2542" Name="蘑菇蜡烛" />
+    <Item Id="2543" Name="蘑菇吊灯" />
+    <Item Id="2544" Name="蘑菇箱" />
+    <Item Id="2545" Name="蘑菇梳妆台" />
+    <Item Id="2546" Name="蘑菇灯笼" />
+    <Item Id="2547" Name="蘑菇灯" />
+    <Item Id="2548" Name="蘑菇钢琴" />
+    <Item Id="2549" Name="蘑菇平台" />
+    <Item Id="2550" Name="蘑菇桌" />
+    <Item Id="2551" Name="蜘蛛法杖" Rack="true" />
+    <Item Id="2552" Name="针叶木浴缸" />
+    <Item Id="2553" Name="针叶木床" />
+    <Item Id="2554" Name="针叶木书架" />
+    <Item Id="2555" Name="针叶木烛台" />
+    <Item Id="2556" Name="针叶木蜡烛" />
+    <Item Id="2557" Name="针叶木椅" />
+    <Item Id="2558" Name="针叶木吊灯" />
+    <Item Id="2559" Name="针叶木箱" />
+    <Item Id="2560" Name="针叶木时钟" />
+    <Item Id="2561" Name="针叶木门" />
+    <Item Id="2562" Name="针叶木梳妆台" />
+    <Item Id="2563" Name="针叶木灯" />
+    <Item Id="2564" Name="针叶木灯笼" />
+    <Item Id="2565" Name="针叶木钢琴" />
+    <Item Id="2566" Name="针叶木平台" />
+    <Item Id="2567" Name="史莱姆浴缸" />
+    <Item Id="2568" Name="史莱姆床" />
+    <Item Id="2569" Name="史莱姆书架" />
+    <Item Id="2570" Name="史莱姆烛台" />
+    <Item Id="2571" Name="史莱姆蜡烛" />
+    <Item Id="2572" Name="史莱姆椅" />
+    <Item Id="2573" Name="史莱姆吊灯" />
+    <Item Id="2574" Name="史莱姆箱" />
+    <Item Id="2575" Name="史莱姆时钟" />
+    <Item Id="2576" Name="史莱姆门" />
+    <Item Id="2577" Name="史莱姆梳妆台" />
+    <Item Id="2578" Name="史莱姆灯" />
+    <Item Id="2579" Name="史莱姆灯笼" />
+    <Item Id="2580" Name="史莱姆钢琴" />
+    <Item Id="2581" Name="史莱姆平台" />
+    <Item Id="2582" Name="史莱姆沙发" />
+    <Item Id="2583" Name="史莱姆桌" />
+    <Item Id="2584" Name="海盗法杖" Rack="true" />
+    <Item Id="2585" Name="史莱姆钩" />
+    <Item Id="2586" Name="粘性手榴弹" Rack="true" />
+    <Item Id="2587" Name="塔塔酱" />
+    <Item Id="2588" Name="猪龙鱼公爵面具" Head="168" />
+    <Item Id="2589" Name="猪龙鱼公爵纪念章" />
+    <Item Id="2590" Name="莫洛托夫鸡尾酒" Rack="true" />
+    <Item Id="2591" Name="骨头时钟" />
+    <Item Id="2592" Name="仙人掌时钟" />
+    <Item Id="2593" Name="乌木时钟" />
+    <Item Id="2594" Name="冰冻时钟" />
+    <Item Id="2595" Name="丛林蜥蜴时钟" />
+    <Item Id="2596" Name="生命木时钟" />
+    <Item Id="2597" Name="红木时钟" />
+    <Item Id="2598" Name="血肉时钟" />
+    <Item Id="2599" Name="蘑菇时钟" />
+    <Item Id="2600" Name="黑曜石时钟" />
+    <Item Id="2601" Name="棕榈木时钟" />
+    <Item Id="2602" Name="珍珠木时钟" />
+    <Item Id="2603" Name="南瓜时钟" />
+    <Item Id="2604" Name="暗影木时钟" />
+    <Item Id="2605" Name="阴森时钟" />
+    <Item Id="2606" Name="天域时钟" />
+    <Item Id="2607" Name="蜘蛛牙" />
+    <Item Id="2608" Name="猎鹰刃" Scale="1.05" Rack="true" />
+    <Item Id="2609" Name="猪龙鱼之翼" />
+    <Item Id="2610" Name="史莱姆枪" Scale="0.9" />
+    <Item Id="2611" Name="猪鲨链球" Rack="true" />
+    <Item Id="2612" Name="绿地牢箱" />
+    <Item Id="2613" Name="粉地牢箱" />
+    <Item Id="2614" Name="蓝地牢箱" />
+    <Item Id="2615" Name="骨箱" />
+    <Item Id="2616" Name="仙人掌箱" />
+    <Item Id="2617" Name="血肉箱" />
+    <Item Id="2618" Name="黑曜石箱" />
+    <Item Id="2619" Name="南瓜箱" />
+    <Item Id="2620" Name="阴森箱" />
+    <Item Id="2621" Name="暴风雨法杖" Rack="true" />
+    <Item Id="2622" Name="利刃台风" Scale="0.9" Rack="true" />
+    <Item Id="2623" Name="泡泡枪" Rack="true" />
+    <Item Id="2624" Name="海啸" Rack="true" />
+    <Item Id="2625" Name="贝壳" />
+    <Item Id="2626" Name="海星" />
+    <Item Id="2627" Name="蒸汽朋克平台" />
+    <Item Id="2628" Name="天域平台" />
+    <Item Id="2629" Name="生命木平台" />
+    <Item Id="2630" Name="蜂蜜平台" />
+    <Item Id="2631" Name="天域工作台" />
+    <Item Id="2632" Name="玻璃工作台" />
+    <Item Id="2633" Name="生命木工作台" />
+    <Item Id="2634" Name="血肉沙发" />
+    <Item Id="2635" Name="冰冻沙发" />
+    <Item Id="2636" Name="生命木沙发" />
+    <Item Id="2637" Name="南瓜梳妆台" />
+    <Item Id="2638" Name="蒸汽朋克梳妆台" />
+    <Item Id="2639" Name="玻璃梳妆台" />
+    <Item Id="2640" Name="血肉梳妆台" />
+    <Item Id="2641" Name="南瓜灯笼" />
+    <Item Id="2642" Name="黑曜石灯笼" />
+    <Item Id="2643" Name="南瓜灯" />
+    <Item Id="2644" Name="黑曜石灯" />
+    <Item Id="2645" Name="蓝地牢灯" />
+    <Item Id="2646" Name="绿地牢灯" />
+    <Item Id="2647" Name="粉地牢灯" />
+    <Item Id="2648" Name="蜂蜜蜡烛" />
+    <Item Id="2649" Name="蒸汽朋克蜡烛" />
+    <Item Id="2650" Name="阴森蜡烛" />
+    <Item Id="2651" Name="黑曜石蜡烛" />
+    <Item Id="2652" Name="蓝地牢吊灯" />
+    <Item Id="2653" Name="绿地牢吊灯" />
+    <Item Id="2654" Name="粉地牢吊灯" />
+    <Item Id="2655" Name="蒸汽朋克吊灯" />
+    <Item Id="2656" Name="南瓜吊灯" />
+    <Item Id="2657" Name="黑曜石吊灯" />
+    <Item Id="2658" Name="蓝地牢浴缸" />
+    <Item Id="2659" Name="绿地牢浴缸" />
+    <Item Id="2660" Name="粉地牢浴缸" />
+    <Item Id="2661" Name="南瓜浴缸" />
+    <Item Id="2662" Name="黑曜石浴缸" />
+    <Item Id="2663" Name="金浴缸" />
+    <Item Id="2664" Name="蓝地牢烛台" />
+    <Item Id="2665" Name="绿地牢烛台" />
+    <Item Id="2666" Name="粉地牢烛台" />
+    <Item Id="2667" Name="黑曜石烛台" />
+    <Item Id="2668" Name="南瓜烛台" />
+    <Item Id="2669" Name="南瓜床" />
+    <Item Id="2670" Name="南瓜书架" />
+    <Item Id="2671" Name="南瓜钢琴" />
+    <Item Id="2672" Name="鲨鱼雕像" />
+    <Item Id="2673" Name="松露虫" />
+    <Item Id="2674" Name="学徒诱饵" />
+    <Item Id="2675" Name="熟手诱饵" />
+    <Item Id="2676" Name="大师诱饵" />
+    <Item Id="2677" Name="琥珀晶莹宝石墙" />
+    <Item Id="2678" Name="黯淡琥珀晶莹宝石墙" />
+    <Item Id="2679" Name="紫晶晶莹宝石墙" />
+    <Item Id="2680" Name="黯淡紫晶晶莹宝石墙" />
+    <Item Id="2681" Name="钻石晶莹宝石墙" />
+    <Item Id="2682" Name="黯淡钻石晶莹宝石墙" />
+    <Item Id="2683" Name="翡翠晶莹宝石墙" />
+    <Item Id="2684" Name="黯淡翡翠晶莹宝石墙" />
+    <Item Id="2685" Name="红玉晶莹宝石墙" />
+    <Item Id="2686" Name="黯淡红玉晶莹宝石墙" />
+    <Item Id="2687" Name="蓝玉晶莹宝石墙" />
+    <Item Id="2688" Name="黯淡蓝玉晶莹宝石墙" />
+    <Item Id="2689" Name="黄玉晶莹宝石墙" />
+    <Item Id="2690" Name="黯淡黄玉晶莹宝石墙" />
+    <Item Id="2691" Name="镀锡墙" />
+    <Item Id="2692" Name="锡镀层" />
+    <Item Id="2693" Name="瀑布块" />
+    <Item Id="2694" Name="熔岩瀑布块" />
+    <Item Id="2695" Name="彩纸块" />
+    <Item Id="2696" Name="彩纸墙" />
+    <Item Id="2697" Name="午夜彩纸块" />
+    <Item Id="2698" Name="午夜彩纸墙" />
+    <Item Id="2699" Name="武器架" />
+    <Item Id="2700" Name="烟花盒" />
+    <Item Id="2701" Name="活火块" />
+    <Item Id="2702" Name="0字雕像" />
+    <Item Id="2703" Name="1字雕像" />
+    <Item Id="2704" Name="2字雕像" />
+    <Item Id="2705" Name="3字雕像" />
+    <Item Id="2706" Name="4字雕像" />
+    <Item Id="2707" Name="5字雕像" />
+    <Item Id="2708" Name="6字雕像" />
+    <Item Id="2709" Name="7字雕像" />
+    <Item Id="2710" Name="8字雕像" />
+    <Item Id="2711" Name="9字雕像" />
+    <Item Id="2712" Name="A字雕像" />
+    <Item Id="2713" Name="B字雕像" />
+    <Item Id="2714" Name="C字雕像" />
+    <Item Id="2715" Name="D字雕像" />
+    <Item Id="2716" Name="E字雕像" />
+    <Item Id="2717" Name="F字雕像" />
+    <Item Id="2718" Name="G字雕像" />
+    <Item Id="2719" Name="H字雕像" />
+    <Item Id="2720" Name="I字雕像" />
+    <Item Id="2721" Name="J字雕像" />
+    <Item Id="2722" Name="K字雕像" />
+    <Item Id="2723" Name="L字雕像" />
+    <Item Id="2724" Name="M字雕像" />
+    <Item Id="2725" Name="N字雕像" />
+    <Item Id="2726" Name="O字雕像" />
+    <Item Id="2727" Name="P字雕像" />
+    <Item Id="2728" Name="Q字雕像" />
+    <Item Id="2729" Name="R字雕像" />
+    <Item Id="2730" Name="S字雕像" />
+    <Item Id="2731" Name="T字雕像" />
+    <Item Id="2732" Name="U字雕像" />
+    <Item Id="2733" Name="V字雕像" />
+    <Item Id="2734" Name="W字雕像" />
+    <Item Id="2735" Name="X字雕像" />
+    <Item Id="2736" Name="Y字雕像" />
+    <Item Id="2737" Name="Z字雕像" />
+    <Item Id="2738" Name="烟花喷泉" />
+    <Item Id="2739" Name="增速轨道" />
+    <Item Id="2740" Name="蚱蜢" />
+    <Item Id="2741" Name="蚱蜢笼" />
+    <Item Id="2742" Name="八音盒（地下猩红之地）" />
+    <Item Id="2743" Name="仙人掌桌" />
+    <Item Id="2744" Name="仙人掌平台" />
+    <Item Id="2745" Name="针叶木剑" Rack="true" />
+    <Item Id="2746" Name="针叶木锤" Scale="1.1" Rack="true" />
+    <Item Id="2747" Name="针叶木弓" Rack="true" />
+    <Item Id="2748" Name="玻璃箱" />
+    <Item Id="2749" Name="外星法杖" Rack="true" />
+    <Item Id="2750" Name="流星法杖" Rack="true" />
+    <Item Id="2751" Name="诅咒活火块" />
+    <Item Id="2752" Name="恶魔活火块" />
+    <Item Id="2753" Name="寒霜活火块" />
+    <Item Id="2754" Name="灵液活火块" />
+    <Item Id="2755" Name="超亮活火块" />
+    <Item Id="2756" Name="变性药水" />
+    <Item Id="2757" Name="星旋头盔" Head="169" />
+    <Item Id="2758" Name="星旋胸甲" Body="175" />
+    <Item Id="2759" Name="星旋护腿" Legs="110" />
+    <Item Id="2760" Name="星云头盔" Head="170" />
+    <Item Id="2761" Name="星云胸甲" Body="176" />
+    <Item Id="2762" Name="星云护腿" Legs="111" />
+    <Item Id="2763" Name="耀斑头盔" Head="171" />
+    <Item Id="2764" Name="耀斑胸甲" Body="177" />
+    <Item Id="2765" Name="耀斑护腿" Legs="112" />
+    <Item Id="2766" Name="日耀碑牌碎片" />
+    <Item Id="2767" Name="日耀碑牌" />
+    <Item Id="2768" Name="钻头控制装置" />
+    <Item Id="2769" Name="宇宙车钥匙" />
+    <Item Id="2770" Name="蛾怪之翼" />
+    <Item Id="2771" Name="扰脑怪" />
+    <Item Id="2772" Name="星旋斧" Scale="1.05" Rack="true" />
+    <Item Id="2773" Name="星旋链锯" Rack="true" />
+    <Item Id="2774" Name="星旋钻头" Rack="true" />
+    <Item Id="2775" Name="星旋锤" Scale="1.1" Rack="true" />
+    <Item Id="2776" Name="星旋镐" Rack="true" />
+    <Item Id="2777" Name="星云斧" Rack="true" />
+    <Item Id="2778" Name="星云链锯" Rack="true" />
+    <Item Id="2779" Name="星云钻头" Rack="true" />
+    <Item Id="2780" Name="星云锤" Rack="true" />
+    <Item Id="2781" Name="星云镐" Rack="true" />
+    <Item Id="2782" Name="耀斑斧" Rack="true" />
+    <Item Id="2783" Name="耀斑链锯" Rack="true" />
+    <Item Id="2784" Name="耀斑钻头" Rack="true" />
+    <Item Id="2785" Name="耀斑锤" Rack="true" />
+    <Item Id="2786" Name="耀斑镐斧" Rack="true" />
+    <Item Id="2787" Name="蜂蜜瀑布块" />
+    <Item Id="2788" Name="蜂蜜瀑布墙" />
+    <Item Id="2789" Name="叶绿砖墙" />
+    <Item Id="2790" Name="猩红矿砖墙" />
+    <Item Id="2791" Name="蘑菇矿镀层墙" />
+    <Item Id="2792" Name="叶绿砖" />
+    <Item Id="2793" Name="猩红矿砖" />
+    <Item Id="2794" Name="蘑菇矿镀层" />
+    <Item Id="2795" Name="激光机枪" Rack="true" />
+    <Item Id="2796" Name="电圈发射器" Rack="true" />
+    <Item Id="2797" Name="外星霰弹枪" Rack="true" />
+    <Item Id="2798" Name="激光钻头" Rack="true" />
+    <Item Id="2799" Name="机械标尺" />
+    <Item Id="2800" Name="反重力钩" />
+    <Item Id="2801" Name="月亮面具" Head="172" />
+    <Item Id="2802" Name="太阳面具" Head="173" />
+    <Item Id="2803" Name="火星制服面具" Head="174" />
+    <Item Id="2804" Name="火星制服衣" Body="178" />
+    <Item Id="2805" Name="火星时装裤" Legs="113" />
+    <Item Id="2806" Name="火星制服头盔" Head="175" />
+    <Item Id="2807" Name="火星制服上衣" Body="179" />
+    <Item Id="2808" Name="火星制服裤" Legs="114" />
+    <Item Id="2809" Name="火星占星钟" />
+    <Item Id="2810" Name="火星浴缸" />
+    <Item Id="2811" Name="火星床" />
+    <Item Id="2812" Name="火星摇摆椅" />
+    <Item Id="2813" Name="火星吊灯" />
+    <Item Id="2814" Name="火星箱" />
+    <Item Id="2815" Name="火星门" />
+    <Item Id="2816" Name="火星梳妆台" />
+    <Item Id="2817" Name="火星整体书架" />
+    <Item Id="2818" Name="火星摇摆蜡烛" />
+    <Item Id="2819" Name="火星灯柱" />
+    <Item Id="2820" Name="火星灯笼" />
+    <Item Id="2821" Name="火星钢琴" />
+    <Item Id="2822" Name="火星平台" />
+    <Item Id="2823" Name="火星沙发" />
+    <Item Id="2824" Name="火星桌" />
+    <Item Id="2825" Name="火星桌灯" />
+    <Item Id="2826" Name="火星工作台" />
+    <Item Id="2827" Name="木水槽" />
+    <Item Id="2828" Name="乌木水槽" />
+    <Item Id="2829" Name="红木水槽" />
+    <Item Id="2830" Name="珍珠木水槽" />
+    <Item Id="2831" Name="骨头水槽" />
+    <Item Id="2832" Name="血肉水槽" />
+    <Item Id="2833" Name="生命木水槽" />
+    <Item Id="2834" Name="天域水槽" />
+    <Item Id="2835" Name="暗影木水槽" />
+    <Item Id="2836" Name="丛林蜥蜴水槽" />
+    <Item Id="2837" Name="蓝地牢水槽" />
+    <Item Id="2838" Name="绿地牢水槽" />
+    <Item Id="2839" Name="粉地牢水槽" />
+    <Item Id="2840" Name="黑曜石水槽" />
+    <Item Id="2841" Name="金属水槽" />
+    <Item Id="2842" Name="玻璃水槽" />
+    <Item Id="2843" Name="金水槽" />
+    <Item Id="2844" Name="蜂蜜水槽" />
+    <Item Id="2845" Name="蒸汽朋克水槽" />
+    <Item Id="2846" Name="南瓜水槽" />
+    <Item Id="2847" Name="阴森水槽" />
+    <Item Id="2848" Name="冰冻水槽" />
+    <Item Id="2849" Name="王朝水槽" />
+    <Item Id="2850" Name="棕榈木水槽" />
+    <Item Id="2851" Name="蘑菇水槽" />
+    <Item Id="2852" Name="针叶木水槽" />
+    <Item Id="2853" Name="史莱姆水槽" />
+    <Item Id="2854" Name="仙人掌水槽" />
+    <Item Id="2855" Name="火星水槽" />
+    <Item Id="2856" Name="日耀邪教徒兜帽" Head="176" />
+    <Item Id="2857" Name="月亮邪教徒兜帽" Head="177" />
+    <Item Id="2858" Name="日耀邪教徒长袍" Body="180" />
+    <Item Id="2859" Name="月亮邪教徒长袍" Body="181" />
+    <Item Id="2860" Name="火星管道镀层" />
+    <Item Id="2861" Name="火星管道墙" />
+    <Item Id="2862" Name="高科技墨镜" Head="178" />
+    <Item Id="2863" Name="火星染发剂" />
+    <Item Id="2864" Name="火星染料" />
+    <Item Id="2865" Name="火星贝格城堡" />
+    <Item Id="2866" Name="火娜丽莎" />
+    <Item Id="2867" Name="真理就在火星" />
+    <Item Id="2868" Name="烟雾块" />
+    <Item Id="2869" Name="鲜艳红焰染料" />
+    <Item Id="2870" Name="鲜艳彩虹染料" />
+    <Item Id="2871" Name="暗影染料" />
+    <Item Id="2872" Name="阴暗染料" />
+    <Item Id="2873" Name="鲜艳海蓝染料" />
+    <Item Id="2874" Name="棕染料" />
+    <Item Id="2875" Name="棕黑染料" />
+    <Item Id="2876" Name="蓝棕染料" />
+    <Item Id="2877" Name="棕银染料" />
+    <Item Id="2878" Name="妖灵染料" />
+    <Item Id="2879" Name="妖精染料" />
+    <Item Id="2880" Name="波涌之刃" Scale="1.05" Rack="true" />
     <Item Id="2881" Name="Phasic Warp Ejector" />
-    <Item Id="2882" Name="Charged Blaster Cannon" Rack="true" />
-    <Item Id="2883" Name="Chlorophyte Dye" />
-    <Item Id="2884" Name="Unicorn Wisp Dye" />
-    <Item Id="2885" Name="Infernal Wisp Dye" />
-    <Item Id="2886" Name="Vicious Powder" />
-    <Item Id="2887" Name="Vicious Mushroom" />
-    <Item Id="2888" Name="The Bee's Knees" Rack="true" />
-    <Item Id="2889" Name="Gold Bird" />
-    <Item Id="2890" Name="Gold Bunny" />
-    <Item Id="2891" Name="Gold Butterfly" />
-    <Item Id="2892" Name="Gold Frog" />
-    <Item Id="2893" Name="Gold Grasshopper" />
-    <Item Id="2894" Name="Gold Mouse" />
-    <Item Id="2895" Name="Gold Worm" />
-    <Item Id="2896" Name="Sticky Dynamite" />
-    <Item Id="2897" Name="Angry Trapper Banner" Tally="88" />
-    <Item Id="2898" Name="Armored Viking Banner" Tally="89" />
-    <Item Id="2899" Name="Black Slime Banner" Tally="90" />
-    <Item Id="2900" Name="Blue Armored Bones Banner" Tally="91" />
-    <Item Id="2901" Name="Blue Cultist Archer Banner" Tally="92" />
-    <Item Id="2902" Name="Blue Cultist Caster Banner" Tally="93" />
-    <Item Id="2903" Name="Blue Cultist Fighter Banner" Tally="94" />
-    <Item Id="2904" Name="Bone Lee Banner" Tally="95" />
-    <Item Id="2905" Name="Clinger Banner" Tally="96" />
-    <Item Id="2906" Name="Cochineal Beetle Banner" Tally="97" />
-    <Item Id="2907" Name="Corrupt Penguin Banner" Tally="98" />
-    <Item Id="2908" Name="Corrupt Slime Banner" Tally="99" />
-    <Item Id="2909" Name="Corruptor Banner" Tally="100" />
-    <Item Id="2910" Name="Crimslime Banner" Tally="101" />
-    <Item Id="2911" Name="Cursed Skull Banner" Tally="102" />
-    <Item Id="2912" Name="Cyan Beetle Banner" Tally="103" />
-    <Item Id="2913" Name="Devourer Banner" Tally="104" />
-    <Item Id="2914" Name="Diabolist Banner" Tally="105" />
-    <Item Id="2915" Name="Doctor Bones Banner" Tally="106" />
-    <Item Id="2916" Name="Dungeon Slime Banner" Tally="107" />
-    <Item Id="2917" Name="Dungeon Spirit Banner" Tally="108" />
-    <Item Id="2918" Name="Elf Archer Banner" Tally="109" />
-    <Item Id="2919" Name="Elf Copter Banner" Tally="110" />
-    <Item Id="2920" Name="Eyezor Banner" Tally="111" />
-    <Item Id="2921" Name="Flocko Banner" Tally="112" />
-    <Item Id="2922" Name="Ghost Banner" Tally="113" />
-    <Item Id="2923" Name="Giant Bat Banner" Tally="114" />
-    <Item Id="2924" Name="Giant Cursed Skull Banner" Tally="115" />
-    <Item Id="2925" Name="Giant Flying Fox Banner" Tally="116" />
-    <Item Id="2926" Name="Gingerbread Man Banner" Tally="117" />
-    <Item Id="2927" Name="Goblin Archer Banner" Tally="118" />
-    <Item Id="2928" Name="Green Slime Banner" Tally="119" />
-    <Item Id="2929" Name="Headless Horseman Banner" Tally="120" />
-    <Item Id="2930" Name="Hell Armored Bones Banner" Tally="121" />
-    <Item Id="2931" Name="Hellhound Banner" Tally="122" />
-    <Item Id="2932" Name="Hoppin' Jack Banner" Tally="123" />
-    <Item Id="2933" Name="Ice Bat Banner" Tally="124" />
-    <Item Id="2934" Name="Ice Golem Banner" Tally="125" />
-    <Item Id="2935" Name="Ice Slime Banner" Tally="126" />
-    <Item Id="2936" Name="Ichor Sticker Banner" Tally="127" />
-    <Item Id="2937" Name="Illuminant Bat Banner" Tally="128" />
-    <Item Id="2938" Name="Illuminant Slime Banner" Tally="129" />
-    <Item Id="2939" Name="Jungle Bat Banner" Tally="130" />
-    <Item Id="2940" Name="Jungle Slime Banner" Tally="131" />
-    <Item Id="2941" Name="Krampus Banner" Tally="132" />
-    <Item Id="2942" Name="Lac Beetle Banner" Tally="133" />
-    <Item Id="2943" Name="Lava Bat Banner" Tally="134" />
-    <Item Id="2944" Name="Lava Slime Banner" Tally="135" />
-    <Item Id="2945" Name="Martian Brainscrambler Banner" Tally="136" />
-    <Item Id="2946" Name="Martian Drone Banner" Tally="137" />
-    <Item Id="2947" Name="Martian Engineer Banner" Tally="138" />
-    <Item Id="2948" Name="Martian Gigazapper Banner" Tally="139" />
-    <Item Id="2949" Name="Martian Gray Grunt Banner" Tally="140" />
-    <Item Id="2950" Name="Martian Officer Banner" Tally="141" />
-    <Item Id="2951" Name="Martian Ray Gunner Banner" Tally="142" />
-    <Item Id="2952" Name="Martian Scutlix Gunner Banner" Tally="143" />
-    <Item Id="2953" Name="Martian Tesla Turret Banner" Tally="144" />
-    <Item Id="2954" Name="Mister Stabby Banner" Tally="145" />
-    <Item Id="2955" Name="Mother Slime Banner" Tally="146" />
-    <Item Id="2956" Name="Necromancer Banner" Tally="147" />
-    <Item Id="2957" Name="Nutcracker Banner" Tally="148" />
-    <Item Id="2958" Name="Paladin Banner" Tally="149" />
-    <Item Id="2959" Name="Penguin Banner" Tally="150" />
-    <Item Id="2960" Name="Pinky Banner" Tally="151" />
-    <Item Id="2961" Name="Poltergeist Banner" Tally="152" />
-    <Item Id="2962" Name="Possessed Armor Banner" Tally="153" />
-    <Item Id="2963" Name="Present Mimic Banner" Tally="154" />
-    <Item Id="2964" Name="Purple Slime Banner" Tally="155" />
-    <Item Id="2965" Name="Ragged Caster Banner" Tally="156" />
-    <Item Id="2966" Name="Rainbow Slime Banner" Tally="157" />
-    <Item Id="2967" Name="Raven Banner" Tally="158" />
-    <Item Id="2968" Name="Red Slime Banner" Tally="159" />
-    <Item Id="2969" Name="Rune Wizard Banner" Tally="160" />
-    <Item Id="2970" Name="Rusty Armored Bones Banner" Tally="161" />
-    <Item Id="2971" Name="Scarecrow Banner" Tally="162" />
-    <Item Id="2972" Name="Scutlix Banner" Tally="163" />
-    <Item Id="2973" Name="Skeleton Archer Banner" Tally="164" />
-    <Item Id="2974" Name="Skeleton Commando Banner" Tally="165" />
-    <Item Id="2975" Name="Skeleton Sniper Banner" Tally="166" />
-    <Item Id="2976" Name="Slimer Banner" Tally="167" />
-    <Item Id="2977" Name="Snatcher Banner" Tally="168" />
-    <Item Id="2978" Name="Snow Balla Banner" Tally="169" />
-    <Item Id="2979" Name="Snowman Gangsta Banner" Tally="170" />
-    <Item Id="2980" Name="Spiked Ice Slime Banner" Tally="171" />
-    <Item Id="2981" Name="Spiked Jungle Slime Banner" Tally="172" />
-    <Item Id="2982" Name="Splinterling Banner" Tally="173" />
-    <Item Id="2983" Name="Squid Banner" Tally="174" />
-    <Item Id="2984" Name="Tactical Skeleton Banner" Tally="175" />
-    <Item Id="2985" Name="The Groom Banner" Tally="176" />
-    <Item Id="2986" Name="Tim Banner" Tally="177" />
-    <Item Id="2987" Name="Undead Miner Banner" Tally="178" />
-    <Item Id="2988" Name="Undead Viking Banner" Tally="179" />
-    <Item Id="2989" Name="White Cultist Archer Banner" Tally="180" />
-    <Item Id="2990" Name="White Cultist Caster Banner" Tally="181" />
-    <Item Id="2991" Name="White Cultist Fighter Banner" Tally="182" />
-    <Item Id="2992" Name="Yellow Slime Banner" Tally="183" />
-    <Item Id="2993" Name="Yeti Banner" Tally="184" />
-    <Item Id="2994" Name="Zombie Elf Banner" Tally="185" />
-    <Item Id="2995" Name="Sparky" />
-    <Item Id="2996" Name="Vine Rope" />
-    <Item Id="2997" Name="Wormhole Potion" />
-    <Item Id="2998" Name="Summoner Emblem" />
-    <Item Id="2999" Name="Bewitching Table" />
-    <Item Id="3000" Name="Alchemy Table" />
-    <Item Id="3001" Name="Strange Brew" />
-    <Item Id="3002" Name="Spelunker Glowstick" />
-    <Item Id="3003" Name="Bone Arrow" Rack="true" />
-    <Item Id="3004" Name="Bone Torch" />
-    <Item Id="3005" Name="Vine Rope Coil" />
-    <Item Id="3006" Name="Life Drain" Rack="true" />
-    <Item Id="3007" Name="Dart Pistol" Scale="0.9" Rack="true" />
-    <Item Id="3008" Name="Dart Rifle" Rack="true" />
-    <Item Id="3009" Name="Crystal Dart" Rack="true" />
-    <Item Id="3010" Name="Cursed Dart" Rack="true" />
-    <Item Id="3011" Name="Ichor Dart" Rack="true" />
-    <Item Id="3012" Name="Chain Guillotines" Rack="true" />
-    <Item Id="3013" Name="Fetid Baghnakhs" Scale="1.35" Rack="true" />
-    <Item Id="3014" Name="Clinger Staff" Rack="true" />
-    <Item Id="3015" Name="Putrid Scent" />
-    <Item Id="3016" Name="Flesh Knuckles" />
-    <Item Id="3017" Name="Flower Boots" />
-    <Item Id="3018" Name="Seedler" Rack="true" />
-    <Item Id="3019" Name="Hellwing Bow" Rack="true" />
-    <Item Id="3020" Name="Tendon Hook" />
-    <Item Id="3021" Name="Thorn Hook" />
-    <Item Id="3022" Name="Illuminant Hook" />
-    <Item Id="3023" Name="Worm Hook" />
-    <Item Id="3024" Name="Skiphs's Blood" />
-    <Item Id="3025" Name="Purple Ooze Dye" />
-    <Item Id="3026" Name="Reflective Silver Dye" />
-    <Item Id="3027" Name="Reflective Gold Dye" />
-    <Item Id="3028" Name="Blue Acid Dye" />
-    <Item Id="3029" Name="Daedalus Stormbow" Rack="true" />
-    <Item Id="3030" Name="Flying Knife" Rack="true" />
-    <Item Id="3031" Name="Bottomless Water Bucket" />
-    <Item Id="3032" Name="Super Absorbant Sponge" />
-    <Item Id="3033" Name="Gold Ring" />
-    <Item Id="3034" Name="Coin Ring" />
-    <Item Id="3035" Name="Greedy Ring" />
-    <Item Id="3036" Name="Fish Finder" />
-    <Item Id="3037" Name="Weather Radio" />
-    <Item Id="3038" Name="Hades Dye" />
-    <Item Id="3039" Name="Twilight Dye" />
-    <Item Id="3040" Name="Acid Dye" />
-    <Item Id="3041" Name="Glowing Mushroom Dye" />
-    <Item Id="3042" Name="Phase Dye" />
-    <Item Id="3043" Name="Magic Lantern" />
-    <Item Id="3044" Name="Music Box (Lunar Boss)" />
-    <Item Id="3045" Name="Rainbow Torch" />
-    <Item Id="3046" Name="Cursed Campfire" />
-    <Item Id="3047" Name="Demon Campfire" />
-    <Item Id="3048" Name="Frozen Campfire" />
-    <Item Id="3049" Name="Ichor Campfire" />
-    <Item Id="3050" Name="Rainbow Campfire" />
-    <Item Id="3051" Name="Crystal Vile Shard" Rack="true" />
-    <Item Id="3052" Name="Shadowflame Bow" Rack="true" />
-    <Item Id="3053" Name="Shadowflame Hex Doll" Rack="true" />
-    <Item Id="3054" Name="Shadowflame Knife" Rack="true" />
-    <Item Id="3055" Name="Acorns" />
-    <Item Id="3056" Name="Cold Snap" />
-    <Item Id="3057" Name="Cursed Saint" />
-    <Item Id="3058" Name="Snowfellas" />
-    <Item Id="3059" Name="The Season" />
-    <Item Id="3060" Name="Bone Rattle" />
-    <Item Id="3061" Name="Architect Gizmo Pack" />
-    <Item Id="3062" Name="Crimson Heart" />
-    <Item Id="3063" Name="Meowmere" Scale="1.1" Rack="true" />
-    <Item Id="3064" Name="Enchanted Sundial" />
-    <Item Id="3065" Name="Star Wrath" Scale="1.1" Rack="true" />
-    <Item Id="3066" Name="Smooth Marble Block" />
-    <Item Id="3067" Name="Hellstone Brick Wall" />
-    <Item Id="3068" Name="Guide to Plant Fiber Cordage" />
-    <Item Id="3069" Name="Wand of Sparking" Rack="true" />
-    <Item Id="3070" Name="Gold Bird Cage" />
-    <Item Id="3071" Name="Gold Bunny Cage" />
-    <Item Id="3072" Name="Gold Butterfly Jar" />
-    <Item Id="3073" Name="Gold Frog Cage" />
-    <Item Id="3074" Name="Gold Grasshopper Cage" />
-    <Item Id="3075" Name="Gold Mouse Cage" />
-    <Item Id="3076" Name="Gold Worm Cage" />
-    <Item Id="3077" Name="Silk Rope" />
-    <Item Id="3078" Name="Web Rope" />
-    <Item Id="3079" Name="Silk Rope Coil" />
-    <Item Id="3080" Name="Web Rope Coil" />
-    <Item Id="3081" Name="Marble Block" />
-    <Item Id="3082" Name="Marble Wall" />
-    <Item Id="3083" Name="Smooth Marble Wall" />
-    <Item Id="3084" Name="Radar" />
-    <Item Id="3085" Name="Golden Lock Box" />
-    <Item Id="3086" Name="Granite Block" />
-    <Item Id="3087" Name="Smooth Granite Block" />
-    <Item Id="3088" Name="Granite Wall" />
-    <Item Id="3089" Name="Smooth Granite Wall" />
-    <Item Id="3090" Name="Royal Gel" />
-    <Item Id="3091" Name="Key of Night" />
-    <Item Id="3092" Name="Key of Light" />
-    <Item Id="3093" Name="Herb Bag" />
-    <Item Id="3094" Name="Javelin" Rack="true" />
-    <Item Id="3095" Name="Tally Counter" />
-    <Item Id="3096" Name="Sextant" />
-    <Item Id="3097" Name="Shield of Cthulhu" Rack="true" />
-    <Item Id="3098" Name="Butcher's Chainsaw" Rack="true" />
-    <Item Id="3099" Name="Stopwatch" />
-    <Item Id="3100" Name="Meteorite Brick" />
-    <Item Id="3101" Name="Meteorite Brick Wall" />
-    <Item Id="3102" Name="Metal Detector" />
-    <Item Id="3103" Name="Endless Quiver" Rack="true" />
-    <Item Id="3104" Name="Endless Musket Pouch" Rack="true" />
-    <Item Id="3105" Name="Toxic Flask" Rack="true" />
-    <Item Id="3106" Name="Psycho Knife" Scale="1.1" Rack="true" />
-    <Item Id="3107" Name="Nail Gun" Rack="true" />
-    <Item Id="3108" Name="Nail" Rack="true" />
-    <Item Id="3109" Name="Night Vision Helmet" Head="179" />
-    <Item Id="3110" Name="Celestial Shell" />
-    <Item Id="3111" Name="Pink Gel" />
-    <Item Id="3112" Name="Bouncy Glowstick" />
-    <Item Id="3113" Name="Pink Slime Block" />
-    <Item Id="3114" Name="Pink Torch" />
-    <Item Id="3115" Name="Bouncy Bomb" />
-    <Item Id="3116" Name="Bouncy Grenade" Rack="true" />
-    <Item Id="3117" Name="Peace Candle" />
-    <Item Id="3118" Name="Lifeform Analyzer" />
-    <Item Id="3119" Name="DPS Meter" />
-    <Item Id="3120" Name="Fisherman's Pocket Guide" />
-    <Item Id="3121" Name="Goblin Tech" />
-    <Item Id="3122" Name="R.E.K. 3000" />
-    <Item Id="3123" Name="PDA" />
-    <Item Id="3124" Name="Cell Phone" />
-    <Item Id="3125" Name="Granite Chest" />
-    <Item Id="3126" Name="Meteorite Clock" />
-    <Item Id="3127" Name="Marble Clock" />
-    <Item Id="3128" Name="Granite Clock" />
-    <Item Id="3129" Name="Meteorite Door" />
-    <Item Id="3130" Name="Marble Door" />
-    <Item Id="3131" Name="Granite Door" />
-    <Item Id="3132" Name="Meteorite Dresser" />
-    <Item Id="3133" Name="Marble Dresser" />
-    <Item Id="3134" Name="Granite Dresser" />
-    <Item Id="3135" Name="Meteorite Lamp" />
-    <Item Id="3136" Name="Marble Lamp" />
-    <Item Id="3137" Name="Granite Lamp" />
-    <Item Id="3138" Name="Meteorite Lantern" />
-    <Item Id="3139" Name="Marble Lantern" />
-    <Item Id="3140" Name="Granite Lantern" />
-    <Item Id="3141" Name="Meteorite Piano" />
-    <Item Id="3142" Name="Marble Piano" />
-    <Item Id="3143" Name="Granite Piano" />
-    <Item Id="3144" Name="Meteorite Platform" />
-    <Item Id="3145" Name="Marble Platform" />
-    <Item Id="3146" Name="Granite Platform" />
-    <Item Id="3147" Name="Meteorite Sink" />
-    <Item Id="3148" Name="Marble Sink" />
-    <Item Id="3149" Name="Granite Sink" />
-    <Item Id="3150" Name="Meteorite Sofa" />
-    <Item Id="3151" Name="Marble Sofa" />
-    <Item Id="3152" Name="Granite Sofa" />
-    <Item Id="3153" Name="Meteorite Table" />
-    <Item Id="3154" Name="Marble Table" />
-    <Item Id="3155" Name="Granite Table" />
-    <Item Id="3156" Name="Meteorite Work Bench" />
-    <Item Id="3157" Name="Marble Work Bench" />
-    <Item Id="3158" Name="Granite Work Bench" />
-    <Item Id="3159" Name="Meteorite Bathtub" />
-    <Item Id="3160" Name="Marble Bathtub" />
-    <Item Id="3161" Name="Granite Bathtub" />
-    <Item Id="3162" Name="Meteorite Bed" />
-    <Item Id="3163" Name="Marble Bed" />
-    <Item Id="3164" Name="Granite Bed" />
-    <Item Id="3165" Name="Meteorite Bookcase" />
-    <Item Id="3166" Name="Marble Bookcase" />
-    <Item Id="3167" Name="Granite Bookcase" />
-    <Item Id="3168" Name="Meteorite Candelabra" />
-    <Item Id="3169" Name="Marble Candelabra" />
-    <Item Id="3170" Name="Granite Candelabra" />
-    <Item Id="3171" Name="Meteorite Candle" />
-    <Item Id="3172" Name="Marble Candle" />
-    <Item Id="3173" Name="Granite Candle" />
-    <Item Id="3174" Name="Meteorite Chair" />
-    <Item Id="3175" Name="Marble Chair" />
-    <Item Id="3176" Name="Granite Chair" />
-    <Item Id="3177" Name="Meteorite Chandelier" />
-    <Item Id="3178" Name="Marble Chandelier" />
-    <Item Id="3179" Name="Granite Chandelier" />
-    <Item Id="3180" Name="Meteorite Chest" />
-    <Item Id="3181" Name="Marble Chest" />
-    <Item Id="3182" Name="Magic Water Dropper" />
-    <Item Id="3183" Name="Golden Bug Net" Scale="1.15" />
-    <Item Id="3184" Name="Magic Lava Dropper" />
-    <Item Id="3185" Name="Magic Honey Dropper" />
-    <Item Id="3186" Name="Empty Dropper" />
-    <Item Id="3187" Name="Gladiator Helmet" Head="180" />
-    <Item Id="3188" Name="Gladiator Breastplate" Body="182" />
-    <Item Id="3189" Name="Gladiator Leggings" Legs="122" />
-    <Item Id="3190" Name="Reflective Dye" />
-    <Item Id="3191" Name="Enchanted Nightcrawler" />
-    <Item Id="3192" Name="Grubby" />
-    <Item Id="3193" Name="Sluggy" />
-    <Item Id="3194" Name="Buggy" />
-    <Item Id="3195" Name="Grub Soup" />
-    <Item Id="3196" Name="Bomb Fish" />
-    <Item Id="3197" Name="Frost Daggerfish" Rack="true" />
-    <Item Id="3198" Name="Sharpening Station" />
-    <Item Id="3199" Name="Ice Mirror" />
-    <Item Id="3200" Name="Sailfish Boots" />
-    <Item Id="3201" Name="Tsunami in a Bottle" />
-    <Item Id="3202" Name="Target Dummy" />
-    <Item Id="3203" Name="Corrupt Crate" />
-    <Item Id="3204" Name="Crimson Crate" />
-    <Item Id="3205" Name="Dungeon Crate" />
-    <Item Id="3206" Name="Sky Crate" />
-    <Item Id="3207" Name="Hallowed Crate" />
-    <Item Id="3208" Name="Jungle Crate" />
-    <Item Id="3209" Name="Crystal Serpent" Rack="true" />
-    <Item Id="3210" Name="Toxikarp" Rack="true" />
-    <Item Id="3211" Name="Bladetongue" Scale="1.125" Rack="true" />
-    <Item Id="3212" Name="Shark Tooth Necklace" />
-    <Item Id="3213" Name="Money Trough" />
-    <Item Id="3214" Name="Bubble" />
-    <Item Id="3215" Name="Daybloom Planter Box" />
-    <Item Id="3216" Name="Moonglow Planter Box" />
-    <Item Id="3217" Name="Deathweed Planter Box" />
-    <Item Id="3218" Name="Deathweed Planter Box" />
-    <Item Id="3219" Name="Blinkroot Planter Box" />
-    <Item Id="3220" Name="Waterleaf Planter Box" />
-    <Item Id="3221" Name="Shiverthorn Planter Box" />
-    <Item Id="3222" Name="Fireblossom Planter Box" />
-    <Item Id="3223" Name="Brain of Confusion" />
-    <Item Id="3224" Name="Worm Scarf" />
-    <Item Id="3225" Name="Balloon Pufferfish" />
-    <Item Id="3226" Name="Lazure's Valkyrie Circlet" Head="181" />
-    <Item Id="3227" Name="Lazure's Valkyrie Cloak" Body="183" />
-    <Item Id="3228" Name="Lazure's Barrier Platform" />
-    <Item Id="3229" Name="Golden Cross Grave Marker" />
-    <Item Id="3230" Name="Golden Tombstone" />
-    <Item Id="3231" Name="Golden Grave Marker" />
-    <Item Id="3232" Name="Golden Gravestone" />
-    <Item Id="3233" Name="Golden Headstone" />
-    <Item Id="3234" Name="Crystal Block" />
-    <Item Id="3235" Name="Music Box (Martian Madness)" />
-    <Item Id="3236" Name="Music Box (Pirate Invasion)" />
-    <Item Id="3237" Name="Music Box (Hell)" />
-    <Item Id="3238" Name="Crystal Block Wall" />
-    <Item Id="3239" Name="Trap Door" />
-    <Item Id="3240" Name="Tall Gate" />
-    <Item Id="3241" Name="Sharkron Balloon" />
-    <Item Id="3242" Name="Tax Collector's Hat" Head="182" />
-    <Item Id="3243" Name="Tax Collector's Suit" Body="184" />
-    <Item Id="3244" Name="Tax Collector's Pants" Legs="124" />
-    <Item Id="3245" Name="Bone Glove" Rack="true" />
-    <Item Id="3246" Name="Clothier's Jacket" Body="185" />
-    <Item Id="3247" Name="Clothier's Pants" Legs="125" />
-    <Item Id="3248" Name="Dye Trader's Turban" Head="183" />
-    <Item Id="3249" Name="Deadly Sphere Staff" Rack="true" />
-    <Item Id="3250" Name="Green Horseshoe Balloon" />
-    <Item Id="3251" Name="Amber Horseshoe Balloon" />
-    <Item Id="3252" Name="Pink Horseshoe Balloon" />
-    <Item Id="3253" Name="Lava Lamp" />
-    <Item Id="3254" Name="Enchanted Nightcrawler Cage" />
-    <Item Id="3255" Name="Buggy Cage" />
-    <Item Id="3256" Name="Grubby Cage" />
-    <Item Id="3257" Name="Sluggy Cage" />
-    <Item Id="3258" Name="Slap Hand" Scale="1.1" Rack="true" />
-    <Item Id="3259" Name="Twilight Hair Dye" />
-    <Item Id="3260" Name="Blessed Apple" />
-    <Item Id="3261" Name="Spectre Bar" />
-    <Item Id="3262" Name="Code 1" Rack="true" />
-    <Item Id="3263" Name="Buccaneer Bandana" Head="184" />
-    <Item Id="3264" Name="Buccaneer Tunic" Body="186" />
-    <Item Id="3265" Name="Buccaneer Pantaloons" Legs="126" />
-    <Item Id="3266" Name="Obsidian Outlaw Hat" Head="185" />
-    <Item Id="3267" Name="Obsidian Longcoat" Body="187" />
-    <Item Id="3268" Name="Obsidian Pants" Legs="127" />
-    <Item Id="3269" Name="Medusa Head" Rack="true" />
-    <Item Id="3270" Name="Item Frame" />
-    <Item Id="3271" Name="Sandstone Block" />
-    <Item Id="3272" Name="Hardened Sand Block" />
-    <Item Id="3273" Name="Sandstone Wall" />
-    <Item Id="3274" Name="Hardened Ebonsand Block" />
-    <Item Id="3275" Name="Hardened Crimsand Block" />
-    <Item Id="3276" Name="Ebonsandstone Block" />
-    <Item Id="3277" Name="Crimsandstone Block" />
-    <Item Id="3278" Name="Wooden Yoyo" Rack="true" />
-    <Item Id="3279" Name="Malaise" Rack="true" />
-    <Item Id="3280" Name="Artery" Rack="true" />
-    <Item Id="3281" Name="Amazon" Rack="true" />
-    <Item Id="3282" Name="Cascade" Rack="true" />
-    <Item Id="3283" Name="Chik" Rack="true" />
-    <Item Id="3284" Name="Code 2" Rack="true" />
-    <Item Id="3285" Name="Rally" Rack="true" />
-    <Item Id="3286" Name="Yelets" Rack="true" />
-    <Item Id="3287" Name="Red's Throw" Rack="true" />
-    <Item Id="3288" Name="Valkyrie Yoyo" Rack="true" />
-    <Item Id="3289" Name="Amarok" Rack="true" />
-    <Item Id="3290" Name="Hel-Fire" Rack="true" />
-    <Item Id="3291" Name="Kraken" Rack="true" />
-    <Item Id="3292" Name="The Eye of Cthulhu" Rack="true" />
-    <Item Id="3293" Name="Red String" />
-    <Item Id="3294" Name="Orange String" />
-    <Item Id="3295" Name="Yellow String" />
-    <Item Id="3296" Name="Lime String" />
-    <Item Id="3297" Name="Green String" />
-    <Item Id="3298" Name="Teal String" />
-    <Item Id="3299" Name="Cyan String" />
-    <Item Id="3300" Name="Sky Blue String" />
-    <Item Id="3301" Name="Blue String" />
-    <Item Id="3302" Name="Purple String" />
-    <Item Id="3303" Name="Violet String" />
-    <Item Id="3304" Name="Pink String" />
-    <Item Id="3305" Name="Brown String" />
-    <Item Id="3306" Name="White String" />
-    <Item Id="3307" Name="Rainbow String" />
-    <Item Id="3308" Name="Black String" />
-    <Item Id="3309" Name="Black Counterweight" />
-    <Item Id="3310" Name="Blue Counterweight" />
-    <Item Id="3311" Name="Green Counterweight" />
-    <Item Id="3312" Name="Purple Counterweight" />
-    <Item Id="3313" Name="Red Counterweight" />
-    <Item Id="3314" Name="Yellow Counterweight" />
-    <Item Id="3315" Name="Format:C" Rack="true" />
-    <Item Id="3316" Name="Gradient" Rack="true" />
-    <Item Id="3317" Name="Valor" Rack="true" />
-    <Item Id="3318" Name="Treasure Bag" />
-    <Item Id="3319" Name="Treasure Bag" />
-    <Item Id="3320" Name="Treasure Bag" />
-    <Item Id="3321" Name="Treasure Bag" />
-    <Item Id="3322" Name="Treasure Bag" />
-    <Item Id="3323" Name="Treasure Bag" />
-    <Item Id="3324" Name="Treasure Bag" />
-    <Item Id="3325" Name="Treasure Bag" />
-    <Item Id="3326" Name="Treasure Bag" />
-    <Item Id="3327" Name="Treasure Bag" />
-    <Item Id="3328" Name="Treasure Bag" />
-    <Item Id="3329" Name="Treasure Bag" />
-    <Item Id="3330" Name="Treasure Bag" />
-    <Item Id="3331" Name="Treasure Bag" />
-    <Item Id="3332" Name="Treasure Bag" />
-    <Item Id="3333" Name="Hive Pack" />
-    <Item Id="3334" Name="Yoyo Glove" />
-    <Item Id="3335" Name="Demon Heart" />
-    <Item Id="3336" Name="Spore Sac" />
-    <Item Id="3337" Name="Shiny Stone" />
-    <Item Id="3338" Name="Hardened Pearlsand Block" />
-    <Item Id="3339" Name="Pearlsandstone Block" />
-    <Item Id="3340" Name="Hardened Sand Wall" />
-    <Item Id="3341" Name="Hardened Ebonsand Wall" />
-    <Item Id="3342" Name="Hardened Crimsand Wall" />
-    <Item Id="3343" Name="Hardened Pearlsand Wall" />
-    <Item Id="3344" Name="Ebonsandstone Wall" />
-    <Item Id="3345" Name="Crimsandstone Wall" />
-    <Item Id="3346" Name="Pearlsandstone Wall" />
-    <Item Id="3347" Name="Desert Fossil" />
-    <Item Id="3348" Name="Desert Fossil Wall" />
-    <Item Id="3349" Name="Exotic Scimitar" Rack="true" />
-    <Item Id="3350" Name="Paintball Gun" Scale="0.85" Rack="true" />
-    <Item Id="3351" Name="Classy Cane" Rack="true" />
-    <Item Id="3352" Name="Stylish Scissors" Rack="true" />
-    <Item Id="3353" Name="Mechanical Cart" />
-    <Item Id="3354" Name="Mechanical Wheel Piece" />
-    <Item Id="3355" Name="Mechanical Wagon Piece" />
-    <Item Id="3356" Name="Mechanical Battery Piece" />
-    <Item Id="3357" Name="Ancient Cultist Trophy" />
-    <Item Id="3358" Name="Martian Saucer Trophy" />
-    <Item Id="3359" Name="Flying Dutchman Trophy" />
-    <Item Id="3360" Name="Living Mahogany Wand" />
-    <Item Id="3361" Name="Rich Mahogany Leaf Wand" />
-    <Item Id="3362" Name="Fallen Tuxedo Shirt" Body="188" />
-    <Item Id="3363" Name="Fallen Tuxedo Pants" Legs="128" />
-    <Item Id="3364" Name="Fireplace" />
-    <Item Id="3365" Name="Chimney" />
-    <Item Id="3366" Name="Yoyo Bag" />
-    <Item Id="3367" Name="Shrimpy Truffle" />
-    <Item Id="3368" Name="Arkhalis" Rack="true" />
-    <Item Id="3369" Name="Confetti Cannon" />
-    <Item Id="3370" Name="Music Box (The Towers)" />
-    <Item Id="3371" Name="Music Box (Goblin Invasion)" />
-    <Item Id="3372" Name="Ancient Cultist Mask" Head="186" />
-    <Item Id="3373" Name="Moon Lord Mask" Head="187" />
-    <Item Id="3374" Name="Fossil Helmet" Head="188" />
-    <Item Id="3375" Name="Fossil Plate" Body="189" />
-    <Item Id="3376" Name="Fossil Greaves" Legs="129" />
-    <Item Id="3377" Name="Amber Staff" Rack="true" />
-    <Item Id="3378" Name="Bone Javelin" Rack="true" />
-    <Item Id="3379" Name="Bone Throwing Knife" Rack="true" />
-    <Item Id="3380" Name="Sturdy Fossil" />
-    <Item Id="3381" Name="Stardust Helmet" Head="189" />
-    <Item Id="3382" Name="Stardust Plate" Body="190" />
-    <Item Id="3383" Name="Stardust Leggings" Legs="130" />
-    <Item Id="3384" Name="Portal Gun" />
-    <Item Id="3385" Name="Strange Plant" />
-    <Item Id="3386" Name="Strange Plant" />
-    <Item Id="3387" Name="Strange Plant" />
-    <Item Id="3388" Name="Strange Plant" />
-    <Item Id="3389" Name="Terrarian" Rack="true" />
-    <Item Id="3390" Name="Goblin Summoner Banner" Tally="186" />
-    <Item Id="3391" Name="Salamander Banner" Tally="187" />
-    <Item Id="3392" Name="Giant Shelly Banner" Tally="188" />
-    <Item Id="3393" Name="Crawdad Banner" Tally="189" />
-    <Item Id="3394" Name="Fritz Banner" Tally="190" />
-    <Item Id="3395" Name="Creature From The Deep Banner" Tally="191" />
-    <Item Id="3396" Name="Dr. Man Fly Banner" Tally="192" />
-    <Item Id="3397" Name="Mothron Banner" Tally="193" />
-    <Item Id="3398" Name="Severed Hand Banner" Tally="194" />
-    <Item Id="3399" Name="The Possessed Banner" Tally="195" />
-    <Item Id="3400" Name="Butcher Banner" Tally="196" />
-    <Item Id="3401" Name="Psycho Banner" Tally="197" />
-    <Item Id="3402" Name="Deadly Sphere Banner" Tally="198" />
-    <Item Id="3403" Name="Nailhead Banner" Tally="199" />
-    <Item Id="3404" Name="Poisonous Spore Banner" Tally="200" />
-    <Item Id="3405" Name="Medusa Banner" Tally="201" />
-    <Item Id="3406" Name="Hoplite Banner" Tally="202" />
-    <Item Id="3407" Name="Granite Elemental Banner" Tally="203" />
+    <Item Id="2882" Name="带电爆破炮" Rack="true" />
+    <Item Id="2883" Name="叶绿染料" />
+    <Item Id="2884" Name="独角妖灵染料" />
+    <Item Id="2885" Name="地狱妖灵染料" />
+    <Item Id="2886" Name="毒粉" />
+    <Item Id="2887" Name="毒蘑菇" />
+    <Item Id="2888" Name="蜂膝弓" Rack="true" />
+    <Item Id="2889" Name="金鸟" />
+    <Item Id="2890" Name="金兔" />
+    <Item Id="2891" Name="金蝴蝶" />
+    <Item Id="2892" Name="金蛙" />
+    <Item Id="2893" Name="金蚱蜢" />
+    <Item Id="2894" Name="金老鼠" />
+    <Item Id="2895" Name="金蠕虫" />
+    <Item Id="2896" Name="粘性雷管" />
+    <Item Id="2897" Name="愤怒捕手旗" Tally="88" />
+    <Item Id="2898" Name="装甲维京海盗旗" Tally="89" />
+    <Item Id="2899" Name="黑史莱姆旗" Tally="90" />
+    <Item Id="2900" Name="蓝装甲骷髅旗" Tally="91" />
+    <Item Id="2901" Name="蓝邪教徒弓箭手旗" Tally="92" />
+    <Item Id="2902" Name="蓝邪教徒法师旗" Tally="93" />
+    <Item Id="2903" Name="蓝邪教徒战士旗" Tally="94" />
+    <Item Id="2904" Name="骷髅李小龙旗" Tally="95" />
+    <Item Id="2905" Name="爬藤怪旗" Tally="96" />
+    <Item Id="2906" Name="胭脂虫旗" Tally="97" />
+    <Item Id="2907" Name="腐化企鹅旗" Tally="98" />
+    <Item Id="2908" Name="腐化史莱姆旗" Tally="99" />
+    <Item Id="2909" Name="腐化者旗" Tally="100" />
+    <Item Id="2910" Name="猩红史莱姆旗" Tally="101" />
+    <Item Id="2911" Name="诅咒骷髅头旗" Tally="102" />
+    <Item Id="2912" Name="青壳虫旗" Tally="103" />
+    <Item Id="2913" Name="吞噬怪旗" Tally="104" />
+    <Item Id="2914" Name="魔教徒旗" Tally="105" />
+    <Item Id="2915" Name="骷髅博士旗" Tally="106" />
+    <Item Id="2916" Name="地牢史莱姆旗" Tally="107" />
+    <Item Id="2917" Name="地牢幽魂旗" Tally="108" />
+    <Item Id="2918" Name="精灵弓箭手旗" Tally="109" />
+    <Item Id="2919" Name="精灵直升机旗" Tally="110" />
+    <Item Id="2920" Name="眼怪旗" Tally="111" />
+    <Item Id="2921" Name="雪花怪旗" Tally="112" />
+    <Item Id="2922" Name="鬼魂旗" Tally="113" />
+    <Item Id="2923" Name="巨型蝙蝠旗" Tally="114" />
+    <Item Id="2924" Name="巨型诅咒骷髅头旗" Tally="115" />
+    <Item Id="2925" Name="巨型飞狐旗" Tally="116" />
+    <Item Id="2926" Name="姜饼人旗" Tally="117" />
+    <Item Id="2927" Name="哥布林弓箭手旗" Tally="118" />
+    <Item Id="2928" Name="绿史莱姆旗" Tally="119" />
+    <Item Id="2929" Name="无头骑士旗" Tally="120" />
+    <Item Id="2930" Name="地狱装甲骷髅旗" Tally="121" />
+    <Item Id="2931" Name="地狱犬旗" Tally="122" />
+    <Item Id="2932" Name="弹跳杰克南瓜灯旗" Tally="123" />
+    <Item Id="2933" Name="冰雪蝙蝠旗" Tally="124" />
+    <Item Id="2934" Name="冰雪巨人旗" Tally="125" />
+    <Item Id="2935" Name="冰雪史莱姆旗" Tally="126" />
+    <Item Id="2936" Name="灵液黏黏怪旗" Tally="127" />
+    <Item Id="2937" Name="夜明蝙蝠旗" Tally="128" />
+    <Item Id="2938" Name="夜明史莱姆旗" Tally="129" />
+    <Item Id="2939" Name="丛林蝙蝠旗" Tally="130" />
+    <Item Id="2940" Name="丛林史莱姆旗" Tally="131" />
+    <Item Id="2941" Name="坎卜斯旗" Tally="132" />
+    <Item Id="2942" Name="紫胶虫旗" Tally="133" />
+    <Item Id="2943" Name="熔岩蝙蝠旗" Tally="134" />
+    <Item Id="2944" Name="熔岩史莱姆旗" Tally="135" />
+    <Item Id="2945" Name="火星扰脑怪旗" Tally="136" />
+    <Item Id="2946" Name="火星飞船旗" Tally="137" />
+    <Item Id="2947" Name="火星工程师旗" Tally="138" />
+    <Item Id="2948" Name="火星电击怪旗" Tally="139" />
+    <Item Id="2949" Name="火星灰咕噜兽旗" Tally="140" />
+    <Item Id="2950" Name="火星军官旗" Tally="141" />
+    <Item Id="2951" Name="火星激光枪手旗" Tally="142" />
+    <Item Id="2952" Name="火星鳞甲怪枪手旗" Tally="143" />
+    <Item Id="2953" Name="火星特斯拉炮塔旗" Tally="144" />
+    <Item Id="2954" Name="戳刺先生旗" Tally="145" />
+    <Item Id="2955" Name="史莱姆之母旗" Tally="146" />
+    <Item Id="2956" Name="死灵法师旗" Tally="147" />
+    <Item Id="2957" Name="胡桃夹士旗" Tally="148" />
+    <Item Id="2958" Name="圣骑士旗" Tally="149" />
+    <Item Id="2959" Name="企鹅旗" Tally="150" />
+    <Item Id="2960" Name="粉史莱姆旗" Tally="151" />
+    <Item Id="2961" Name="胡闹鬼旗" Tally="152" />
+    <Item Id="2962" Name="装甲幻影魔旗" Tally="153" />
+    <Item Id="2963" Name="礼物宝箱怪旗" Tally="154" />
+    <Item Id="2964" Name="紫史莱姆旗" Tally="155" />
+    <Item Id="2965" Name="褴褛邪教徒法师旗" Tally="156" />
+    <Item Id="2966" Name="彩虹史莱姆旗" Tally="157" />
+    <Item Id="2967" Name="乌鸦旗" Tally="158" />
+    <Item Id="2968" Name="红史莱姆旗" Tally="159" />
+    <Item Id="2969" Name="符文巫师旗" Tally="160" />
+    <Item Id="2970" Name="生锈装甲骷髅旗" Tally="161" />
+    <Item Id="2971" Name="稻草人旗" Tally="162" />
+    <Item Id="2972" Name="鳞甲怪旗" Tally="163" />
+    <Item Id="2973" Name="骷髅弓箭手旗" Tally="164" />
+    <Item Id="2974" Name="骷髅突击手旗" Tally="165" />
+    <Item Id="2975" Name="骷髅狙击手旗" Tally="166" />
+    <Item Id="2976" Name="恶翅史莱姆旗" Tally="167" />
+    <Item Id="2977" Name="抓人草旗" Tally="168" />
+    <Item Id="2978" Name="巴拉雪人旗" Tally="169" />
+    <Item Id="2979" Name="雪人暴徒旗" Tally="170" />
+    <Item Id="2980" Name="尖刺冰雪史莱姆旗" Tally="171" />
+    <Item Id="2981" Name="尖刺丛林史莱姆旗" Tally="172" />
+    <Item Id="2982" Name="树精旗" Tally="173" />
+    <Item Id="2983" Name="乌贼旗" Tally="174" />
+    <Item Id="2984" Name="骷髅特警旗" Tally="175" />
+    <Item Id="2985" Name="僵尸新郎旗" Tally="176" />
+    <Item Id="2986" Name="蒂姆旗" Tally="177" />
+    <Item Id="2987" Name="不死矿工旗" Tally="178" />
+    <Item Id="2988" Name="亡灵维京海盗旗" Tally="179" />
+    <Item Id="2989" Name="白邪教徒弓箭手旗" Tally="180" />
+    <Item Id="2990" Name="白邪教徒法师旗" Tally="181" />
+    <Item Id="2991" Name="白邪教徒战士旗" Tally="182" />
+    <Item Id="2992" Name="黄史莱姆旗" Tally="183" />
+    <Item Id="2993" Name="雪兽旗" Tally="184" />
+    <Item Id="2994" Name="僵尸精灵旗" Tally="185" />
+    <Item Id="2995" Name="狗狗斯派基" />
+    <Item Id="2996" Name="藤蔓绳" />
+    <Item Id="2997" Name="虫洞药水" />
+    <Item Id="2998" Name="召唤师徽章" />
+    <Item Id="2999" Name="施法桌" />
+    <Item Id="3000" Name="炼药桌" />
+    <Item Id="3001" Name="诡药" />
+    <Item Id="3002" Name="洞穴探险荧光棒" />
+    <Item Id="3003" Name="骨箭" Rack="true" />
+    <Item Id="3004" Name="骨头火把" />
+    <Item Id="3005" Name="藤蔓绳圈" />
+    <Item Id="3006" Name="夺命杖" Rack="true" />
+    <Item Id="3007" Name="飞镖手枪" Scale="0.9" Rack="true" />
+    <Item Id="3008" Name="飞镖步枪" Rack="true" />
+    <Item Id="3009" Name="水晶镖" Rack="true" />
+    <Item Id="3010" Name="诅咒镖" Rack="true" />
+    <Item Id="3011" Name="灵液镖" Rack="true" />
+    <Item Id="3012" Name="铁链血滴子" Rack="true" />
+    <Item Id="3013" Name="臭虎爪" Scale="1.35" Rack="true" />
+    <Item Id="3014" Name="爬藤怪法杖" Rack="true" />
+    <Item Id="3015" Name="腐香囊" />
+    <Item Id="3016" Name="血肉指关节" />
+    <Item Id="3017" Name="花靴" />
+    <Item Id="3018" Name="种子弯刀" Rack="true" />
+    <Item Id="3019" Name="地狱之翼弓" Rack="true" />
+    <Item Id="3020" Name="肌腱钩" />
+    <Item Id="3021" Name="刺钩" />
+    <Item Id="3022" Name="荧光钩" />
+    <Item Id="3023" Name="蠕虫钩" />
+    <Item Id="3024" Name="Skiphs的血" />
+    <Item Id="3025" Name="紫泥染料" />
+    <Item Id="3026" Name="反光银染料" />
+    <Item Id="3027" Name="反光金染料" />
+    <Item Id="3028" Name="蓝酸性染料" />
+    <Item Id="3029" Name="代达罗斯风暴弓" Rack="true" />
+    <Item Id="3030" Name="飞刀" Rack="true" />
+    <Item Id="3031" Name="无底水桶" />
+    <Item Id="3032" Name="超级吸水棉" />
+    <Item Id="3033" Name="金戒指" />
+    <Item Id="3034" Name="钱币戒指" />
+    <Item Id="3035" Name="贪婪戒指" />
+    <Item Id="3036" Name="探鱼器" />
+    <Item Id="3037" Name="天气收音机" />
+    <Item Id="3038" Name="冥王染料" />
+    <Item Id="3039" Name="暮光染料" />
+    <Item Id="3040" Name="酸性染料" />
+    <Item Id="3041" Name="发光蘑菇染料" />
+    <Item Id="3042" Name="闪光染料" />
+    <Item Id="3043" Name="魔法灯笼" />
+    <Item Id="3044" Name="八音盒（月亮Boss）" />
+    <Item Id="3045" Name="彩虹火把" />
+    <Item Id="3046" Name="诅咒篝火" />
+    <Item Id="3047" Name="恶魔篝火" />
+    <Item Id="3048" Name="冰冻篝火" />
+    <Item Id="3049" Name="灵液篝火" />
+    <Item Id="3050" Name="彩虹篝火" />
+    <Item Id="3051" Name="魔晶碎块" Rack="true" />
+    <Item Id="3052" Name="暗影焰弓" Rack="true" />
+    <Item Id="3053" Name="暗影焰妖娃" Rack="true" />
+    <Item Id="3054" Name="暗影焰刀" Rack="true" />
+    <Item Id="3055" Name="橡果" />
+    <Item Id="3056" Name="寒冰英姿" />
+    <Item Id="3057" Name="诅咒的圣诞骷髅王" />
+    <Item Id="3058" Name="吉祥三雪宝" />
+    <Item Id="3059" Name="圣诞雪季" />
+    <Item Id="3060" Name="骨头宝" />
+    <Item Id="3061" Name="建筑师发明背包" />
+    <Item Id="3062" Name="猩红之心" />
+    <Item Id="3063" Name="彩虹猫之刃" Scale="1.1" Rack="true" />
+    <Item Id="3064" Name="附魔日晷" />
+    <Item Id="3065" Name="狂星之怒" Scale="1.1" Rack="true" />
+    <Item Id="3066" Name="光面大理石块" />
+    <Item Id="3067" Name="狱石砖墙" />
+    <Item Id="3068" Name="植物纤维绳索宝典" />
+    <Item Id="3069" Name="火花魔棒" Rack="true" />
+    <Item Id="3070" Name="金鸟笼" />
+    <Item Id="3071" Name="金兔笼" />
+    <Item Id="3072" Name="金蝴蝶罐" />
+    <Item Id="3073" Name="金蛙笼" />
+    <Item Id="3074" Name="金蚱蜢笼" />
+    <Item Id="3075" Name="金老鼠笼" />
+    <Item Id="3076" Name="金蠕虫笼" />
+    <Item Id="3077" Name="丝绸绳" />
+    <Item Id="3078" Name="蛛丝绳" />
+    <Item Id="3079" Name="丝绸绳圈" />
+    <Item Id="3080" Name="蛛丝绳圈" />
+    <Item Id="3081" Name="大理石块" />
+    <Item Id="3082" Name="大理石墙" />
+    <Item Id="3083" Name="光面大理石墙" />
+    <Item Id="3084" Name="雷达" />
+    <Item Id="3085" Name="金锁盒" />
+    <Item Id="3086" Name="花岗岩块" />
+    <Item Id="3087" Name="光面花岗岩块" />
+    <Item Id="3088" Name="花岗岩墙" />
+    <Item Id="3089" Name="光面花岗岩墙" />
+    <Item Id="3090" Name="皇家凝胶" />
+    <Item Id="3091" Name="夜光钥匙" />
+    <Item Id="3092" Name="光明钥匙" />
+    <Item Id="3093" Name="草药袋" />
+    <Item Id="3094" Name="标枪" Rack="true" />
+    <Item Id="3095" Name="杀怪计数器" />
+    <Item Id="3096" Name="六分仪" />
+    <Item Id="3097" Name="克苏鲁护盾" Rack="true" />
+    <Item Id="3098" Name="屠夫链锯" Rack="true" />
+    <Item Id="3099" Name="秒表" />
+    <Item Id="3100" Name="陨石砖" />
+    <Item Id="3101" Name="陨石砖墙" />
+    <Item Id="3102" Name="金属探测器" />
+    <Item Id="3103" Name="无尽箭袋" Rack="true" />
+    <Item Id="3104" Name="无尽火枪袋" Rack="true" />
+    <Item Id="3105" Name="毒气瓶" Rack="true" />
+    <Item Id="3106" Name="变态刀" Scale="1.1" Rack="true" />
+    <Item Id="3107" Name="钉枪" Rack="true" />
+    <Item Id="3108" Name="钉子" Rack="true" />
+    <Item Id="3109" Name="夜视头盔" Head="179" />
+    <Item Id="3110" Name="天界壳" />
+    <Item Id="3111" Name="粉凝胶" />
+    <Item Id="3112" Name="弹力荧光棒" />
+    <Item Id="3113" Name="粉史莱姆块" />
+    <Item Id="3114" Name="粉火把" />
+    <Item Id="3115" Name="弹力炸弹" />
+    <Item Id="3116" Name="弹力手榴弹" Rack="true" />
+    <Item Id="3117" Name="和平蜡烛" />
+    <Item Id="3118" Name="生命体分析机" />
+    <Item Id="3119" Name="每秒伤害计数器" />
+    <Item Id="3120" Name="渔民袖珍宝典" />
+    <Item Id="3121" Name="哥布林数据仪" />
+    <Item Id="3122" Name="R.E.K.3000" />
+    <Item Id="3123" Name="个人数字助手" />
+    <Item Id="3124" Name="手机" />
+    <Item Id="3125" Name="花岗岩箱" />
+    <Item Id="3126" Name="陨石钟" />
+    <Item Id="3127" Name="大理石时钟" />
+    <Item Id="3128" Name="花岗岩时钟" />
+    <Item Id="3129" Name="陨石门" />
+    <Item Id="3130" Name="大理石门" />
+    <Item Id="3131" Name="花岗岩门" />
+    <Item Id="3132" Name="陨石梳妆台" />
+    <Item Id="3133" Name="大理石梳妆台" />
+    <Item Id="3134" Name="花岗岩梳妆台" />
+    <Item Id="3135" Name="陨石灯" />
+    <Item Id="3136" Name="大理石灯" />
+    <Item Id="3137" Name="花岗岩灯" />
+    <Item Id="3138" Name="陨石灯笼" />
+    <Item Id="3139" Name="大理石灯笼" />
+    <Item Id="3140" Name="花岗岩灯笼" />
+    <Item Id="3141" Name="陨石钢琴" />
+    <Item Id="3142" Name="大理石钢琴" />
+    <Item Id="3143" Name="花岗岩钢琴" />
+    <Item Id="3144" Name="陨石平台" />
+    <Item Id="3145" Name="大理石平台" />
+    <Item Id="3146" Name="花岗岩平台" />
+    <Item Id="3147" Name="陨石水槽" />
+    <Item Id="3148" Name="大理石水槽" />
+    <Item Id="3149" Name="花岗岩水槽" />
+    <Item Id="3150" Name="陨石沙发" />
+    <Item Id="3151" Name="大理石沙发" />
+    <Item Id="3152" Name="花岗岩沙发" />
+    <Item Id="3153" Name="陨石桌" />
+    <Item Id="3154" Name="大理石桌" />
+    <Item Id="3155" Name="花岗岩桌" />
+    <Item Id="3156" Name="陨石工作台" />
+    <Item Id="3157" Name="大理石工作台" />
+    <Item Id="3158" Name="花岗岩工作台" />
+    <Item Id="3159" Name="陨石浴缸" />
+    <Item Id="3160" Name="大理石浴缸" />
+    <Item Id="3161" Name="花岗岩浴缸" />
+    <Item Id="3162" Name="陨石床" />
+    <Item Id="3163" Name="大理石床" />
+    <Item Id="3164" Name="花岗岩床" />
+    <Item Id="3165" Name="陨石书架" />
+    <Item Id="3166" Name="大理石书架" />
+    <Item Id="3167" Name="花岗岩书架" />
+    <Item Id="3168" Name="陨石烛台" />
+    <Item Id="3169" Name="大理石烛台" />
+    <Item Id="3170" Name="花岗岩烛台" />
+    <Item Id="3171" Name="陨石蜡烛" />
+    <Item Id="3172" Name="大理石蜡烛" />
+    <Item Id="3173" Name="花岗岩蜡烛" />
+    <Item Id="3174" Name="陨石椅" />
+    <Item Id="3175" Name="大理石椅" />
+    <Item Id="3176" Name="花岗岩椅" />
+    <Item Id="3177" Name="陨石吊灯" />
+    <Item Id="3178" Name="大理石吊灯" />
+    <Item Id="3179" Name="花岗岩吊灯" />
+    <Item Id="3180" Name="陨石箱" />
+    <Item Id="3181" Name="大理石箱" />
+    <Item Id="3182" Name="魔法滴水管" />
+    <Item Id="3183" Name="金虫网" Scale="1.15" />
+    <Item Id="3184" Name="魔法熔岩滴管" />
+    <Item Id="3185" Name="魔法蜂蜜滴管" />
+    <Item Id="3186" Name="空滴管" />
+    <Item Id="3187" Name="勇士头盔" Head="180" />
+    <Item Id="3188" Name="勇士胸甲" Body="182" />
+    <Item Id="3189" Name="勇士护腿" Legs="122" />
+    <Item Id="3190" Name="反光染料" />
+    <Item Id="3191" Name="附魔夜行者" />
+    <Item Id="3192" Name="蛆虫" />
+    <Item Id="3193" Name="鼻涕虫" />
+    <Item Id="3194" Name="蚜虫" />
+    <Item Id="3195" Name="蛆虫汤" />
+    <Item Id="3196" Name="炸弹鱼" />
+    <Item Id="3197" Name="寒霜飞鱼" Rack="true" />
+    <Item Id="3198" Name="利器站" />
+    <Item Id="3199" Name="冰雪镜" />
+    <Item Id="3200" Name="航鱼靴" />
+    <Item Id="3201" Name="海啸瓶" />
+    <Item Id="3202" Name="傀儡" />
+    <Item Id="3203" Name="腐化匣" />
+    <Item Id="3204" Name="猩红匣" />
+    <Item Id="3205" Name="地牢匣" />
+    <Item Id="3206" Name="天空匣" />
+    <Item Id="3207" Name="神圣匣" />
+    <Item Id="3208" Name="丛林匣" />
+    <Item Id="3209" Name="水晶蛇" Rack="true" />
+    <Item Id="3210" Name="毒弹枪" Rack="true" />
+    <Item Id="3211" Name="舌锋剑" Scale="1.125" Rack="true" />
+    <Item Id="3212" Name="鲨牙项链" />
+    <Item Id="3213" Name="钱币槽" />
+    <Item Id="3214" Name="泡泡" />
+    <Item Id="3215" Name="太阳花种植盆" />
+    <Item Id="3216" Name="月光草花盆" />
+    <Item Id="3217" Name="死亡草种植盆" />
+    <Item Id="3218" Name="死亡草种植盆" />
+    <Item Id="3219" Name="闪耀根种植盆" />
+    <Item Id="3220" Name="幌菊花盆" />
+    <Item Id="3221" Name="寒颤棘种植盆" />
+    <Item Id="3222" Name="火焰花花盆" />
+    <Item Id="3223" Name="混乱之脑" />
+    <Item Id="3224" Name="蠕虫围巾" />
+    <Item Id="3225" Name="气球河豚鱼" />
+    <Item Id="3226" Name="Lazure的女武神头环" Head="181" />
+    <Item Id="3227" Name="Lazure的女武神斗蓬" Body="183" />
+    <Item Id="3228" Name="Lazure的屏障台" />
+    <Item Id="3229" Name="金十字墓石碑" />
+    <Item Id="3230" Name="金墓石" />
+    <Item Id="3231" Name="金墓石碑" />
+    <Item Id="3232" Name="金墓碑" />
+    <Item Id="3233" Name="金碑石" />
+    <Item Id="3234" Name="水晶块" />
+    <Item Id="3235" Name="八音盒（火星暴乱）" />
+    <Item Id="3236" Name="八音盒（海盗入侵）" />
+    <Item Id="3237" Name="八音盒（地狱）" />
+    <Item Id="3238" Name="水晶块墙" />
+    <Item Id="3239" Name="机关门" />
+    <Item Id="3240" Name="高门" />
+    <Item Id="3241" Name="鲨鱼龙气球" />
+    <Item Id="3242" Name="税收官帽" Head="182" />
+    <Item Id="3243" Name="税收官套装" Body="184" />
+    <Item Id="3244" Name="税收官裤" Legs="124" />
+    <Item Id="3245" Name="骨头手套" Rack="true" />
+    <Item Id="3246" Name="服装商夹克" Body="185" />
+    <Item Id="3247" Name="服装商裤" Legs="125" />
+    <Item Id="3248" Name="染料商头巾" Head="183" />
+    <Item Id="3249" Name="致命球法杖" Rack="true" />
+    <Item Id="3250" Name="绿马蹄气球" />
+    <Item Id="3251" Name="琥珀马掌气球" />
+    <Item Id="3252" Name="粉马蹄气球" />
+    <Item Id="3253" Name="熔岩灯" />
+    <Item Id="3254" Name="附魔夜行者笼" />
+    <Item Id="3255" Name="蚜虫笼" />
+    <Item Id="3256" Name="蛆虫笼" />
+    <Item Id="3257" Name="鼻涕虫笼" />
+    <Item Id="3258" Name="拍拍手" Scale="1.1" Rack="true" />
+    <Item Id="3259" Name="暮光染发剂" />
+    <Item Id="3260" Name="恩赐苹果" />
+    <Item Id="3261" Name="幽灵锭" />
+    <Item Id="3262" Name="代码1球" Rack="true" />
+    <Item Id="3263" Name="西域海盗头巾" Head="184" />
+    <Item Id="3264" Name="西域海盗上装" Body="186" />
+    <Item Id="3265" Name="西域海盗马裤" Legs="126" />
+    <Item Id="3266" Name="黑曜石逃犯帽" Head="185" />
+    <Item Id="3267" Name="黑曜石风衣" Body="187" />
+    <Item Id="3268" Name="黑曜石裤" Legs="127" />
+    <Item Id="3269" Name="蛇发女妖头" Rack="true" />
+    <Item Id="3270" Name="物品框" />
+    <Item Id="3271" Name="沙岩块" />
+    <Item Id="3272" Name="硬化沙块" />
+    <Item Id="3273" Name="沙岩墙" />
+    <Item Id="3274" Name="硬化黑檀沙块" />
+    <Item Id="3275" Name="硬化猩红沙块" />
+    <Item Id="3276" Name="黑檀沙岩块" />
+    <Item Id="3277" Name="猩红沙岩块" />
+    <Item Id="3278" Name="木悠悠球" Rack="true" />
+    <Item Id="3279" Name="抑郁球" Rack="true" />
+    <Item Id="3280" Name="血脉球" Rack="true" />
+    <Item Id="3281" Name="亚马逊球" Rack="true" />
+    <Item Id="3282" Name="喷流球" Rack="true" />
+    <Item Id="3283" Name="吉克球" Rack="true" />
+    <Item Id="3284" Name="代码2球" Rack="true" />
+    <Item Id="3285" Name="对打球" Rack="true" />
+    <Item Id="3286" Name="叶列茨球" Rack="true" />
+    <Item Id="3287" Name="Red的抛球" Rack="true" />
+    <Item Id="3288" Name="女武神悠悠球" Rack="true" />
+    <Item Id="3289" Name="冰雪悠悠球" Rack="true" />
+    <Item Id="3290" Name="狱火球" Rack="true" />
+    <Item Id="3291" Name="克拉肯球" Rack="true" />
+    <Item Id="3292" Name="克苏鲁之眼" Rack="true" />
+    <Item Id="3293" Name="红绳" />
+    <Item Id="3294" Name="橙绳" />
+    <Item Id="3295" Name="黄绳" />
+    <Item Id="3296" Name="绿黄绳" />
+    <Item Id="3297" Name="绿绳" />
+    <Item Id="3298" Name="青绳" />
+    <Item Id="3299" Name="蓝绿绳" />
+    <Item Id="3300" Name="天蓝绳" />
+    <Item Id="3301" Name="蓝绳" />
+    <Item Id="3302" Name="紫绳" />
+    <Item Id="3303" Name="紫罗兰绳" />
+    <Item Id="3304" Name="粉绳" />
+    <Item Id="3305" Name="棕绳" />
+    <Item Id="3306" Name="白绳" />
+    <Item Id="3307" Name="彩虹绳" />
+    <Item Id="3308" Name="黑绳" />
+    <Item Id="3309" Name="黑平衡锤" />
+    <Item Id="3310" Name="蓝平衡锤" />
+    <Item Id="3311" Name="绿平衡锤" />
+    <Item Id="3312" Name="紫平衡锤" />
+    <Item Id="3313" Name="红平衡锤" />
+    <Item Id="3314" Name="黄平衡锤" />
+    <Item Id="3315" Name="好胜球" Rack="true" />
+    <Item Id="3316" Name="渐变球" Rack="true" />
+    <Item Id="3317" Name="英勇球" Rack="true" />
+    <Item Id="3318" Name="宝藏袋" />
+    <Item Id="3319" Name="宝藏袋" />
+    <Item Id="3320" Name="宝藏袋" />
+    <Item Id="3321" Name="宝藏袋" />
+    <Item Id="3322" Name="宝藏袋" />
+    <Item Id="3323" Name="宝藏袋" />
+    <Item Id="3324" Name="宝藏袋" />
+    <Item Id="3325" Name="宝藏袋" />
+    <Item Id="3326" Name="宝藏袋" />
+    <Item Id="3327" Name="宝藏袋" />
+    <Item Id="3328" Name="宝藏袋" />
+    <Item Id="3329" Name="宝藏袋" />
+    <Item Id="3330" Name="宝藏袋" />
+    <Item Id="3331" Name="宝藏袋" />
+    <Item Id="3332" Name="宝藏袋" />
+    <Item Id="3333" Name="蜂巢背包" />
+    <Item Id="3334" Name="悠悠球手套" />
+    <Item Id="3335" Name="恶魔之心" />
+    <Item Id="3336" Name="孢子囊" />
+    <Item Id="3337" Name="闪亮石" />
+    <Item Id="3338" Name="硬化珍珠沙块" />
+    <Item Id="3339" Name="珍珠沙岩块" />
+    <Item Id="3340" Name="硬化沙墙" />
+    <Item Id="3341" Name="硬化黑檀沙墙" />
+    <Item Id="3342" Name="硬化猩红沙墙" />
+    <Item Id="3343" Name="硬化珍珠沙墙" />
+    <Item Id="3344" Name="黑檀沙岩墙" />
+    <Item Id="3345" Name="猩红沙岩墙" />
+    <Item Id="3346" Name="珍珠沙岩墙" />
+    <Item Id="3347" Name="沙漠化石" />
+    <Item Id="3348" Name="沙漠化石墙" />
+    <Item Id="3349" Name="外星弯刀" Rack="true" />
+    <Item Id="3350" Name="彩弹枪" Scale="0.85" Rack="true" />
+    <Item Id="3351" Name="精致手杖" Rack="true" />
+    <Item Id="3352" Name="时尚剪刀" Rack="true" />
+    <Item Id="3353" Name="机械货车" />
+    <Item Id="3354" Name="机械车轮片" />
+    <Item Id="3355" Name="机械车体片" />
+    <Item Id="3356" Name="机械电池片" />
+    <Item Id="3357" Name="远古邪教徒纪念章" />
+    <Item Id="3358" Name="火星飞碟纪念章" />
+    <Item Id="3359" Name="荷兰飞盗船纪念章" />
+    <Item Id="3360" Name="生命红木魔棒" />
+    <Item Id="3361" Name="红木树叶魔棒" />
+    <Item Id="3362" Name="堕落西装衣" Body="188" />
+    <Item Id="3363" Name="堕落西装裤" Legs="128" />
+    <Item Id="3364" Name="壁炉" />
+    <Item Id="3365" Name="烟囱" />
+    <Item Id="3366" Name="悠悠球袋" />
+    <Item Id="3367" Name="虾松露" />
+    <Item Id="3368" Name="Arkhalis剑" Rack="true" />
+    <Item Id="3369" Name="彩纸炮" />
+    <Item Id="3370" Name="八音盒（神塔）" />
+    <Item Id="3371" Name="八音盒（哥布林入侵）" />
+    <Item Id="3372" Name="远古邪教徒面具" Head="186" />
+    <Item Id="3373" Name="月亮领主面具" Head="187" />
+    <Item Id="3374" Name="化石头盔" Head="188" />
+    <Item Id="3375" Name="化石板甲" Body="189" />
+    <Item Id="3376" Name="化石护胫" Legs="129" />
+    <Item Id="3377" Name="琥珀法杖" Rack="true" />
+    <Item Id="3378" Name="骨头标枪" Rack="true" />
+    <Item Id="3379" Name="骨投刀" Rack="true" />
+    <Item Id="3380" Name="坚固头盔" />
+    <Item Id="3381" Name="星尘头盔" Head="189" />
+    <Item Id="3382" Name="星尘板甲" Body="190" />
+    <Item Id="3383" Name="星尘护腿" Legs="130" />
+    <Item Id="3384" Name="传送枪" />
+    <Item Id="3385" Name="奇异植物" />
+    <Item Id="3386" Name="奇异植物" />
+    <Item Id="3387" Name="奇异植物" />
+    <Item Id="3388" Name="奇异植物" />
+    <Item Id="3389" Name="泰拉悠悠球" Rack="true" />
+    <Item Id="3390" Name="哥布林召唤师旗" Tally="186" />
+    <Item Id="3391" Name="蝾螈旗" Tally="187" />
+    <Item Id="3392" Name="巨型卷壳怪旗" Tally="188" />
+    <Item Id="3393" Name="龙虾旗" Tally="189" />
+    <Item Id="3394" Name="弗里茨旗" Tally="190" />
+    <Item Id="3395" Name="水月怪旗" Tally="191" />
+    <Item Id="3396" Name="飞人博士旗" Tally="192" />
+    <Item Id="3397" Name="蛾怪旗" Tally="193" />
+    <Item Id="3398" Name="残手旗" Tally="194" />
+    <Item Id="3399" Name="攀爬魔旗" Tally="195" />
+    <Item Id="3400" Name="屠夫旗" Tally="196" />
+    <Item Id="3401" Name="变态人旗" Tally="197" />
+    <Item Id="3402" Name="致命球旗" Tally="198" />
+    <Item Id="3403" Name="钉头旗" Tally="199" />
+    <Item Id="3404" Name="毒孢旗" Tally="200" />
+    <Item Id="3405" Name="蛇发女妖旗" Tally="201" />
+    <Item Id="3406" Name="装甲步兵旗" Tally="202" />
+    <Item Id="3407" Name="花岗精旗" Tally="203" />
     <Item Id="3408" Name="Grolem Banner" Tally="204" />
-    <Item Id="3409" Name="Blood Zombie Banner" Tally="205" />
-    <Item Id="3410" Name="Drippler Banner" Tally="206" />
-    <Item Id="3411" Name="Tomb Crawler Banner" Tally="207" />
-    <Item Id="3412" Name="Dune Splicer Banner" Tally="208" />
-    <Item Id="3413" Name="Antlion Swarmer Banner" Tally="209" />
-    <Item Id="3414" Name="Antlion Charger Banner" Tally="210" />
-    <Item Id="3415" Name="Ghoul Banner" Tally="211" />
-    <Item Id="3416" Name="Lamia Banner" Tally="212" />
-    <Item Id="3417" Name="Desert Spirit Banner" Tally="213" />
-    <Item Id="3418" Name="Basilisk Banner" Tally="214" />
+    <Item Id="3409" Name="血腥僵尸旗" Tally="205" />
+    <Item Id="3410" Name="滴滴怪旗" Tally="206" />
+    <Item Id="3411" Name="墓穴爬虫旗" Tally="207" />
+    <Item Id="3412" Name="沙虫旗" Tally="208" />
+    <Item Id="3413" Name="蚁狮蜂旗" Tally="209" />
+    <Item Id="3414" Name="蚁狮马旗" Tally="210" />
+    <Item Id="3415" Name="食尸鬼旗" Tally="211" />
+    <Item Id="3416" Name="拉弥亚旗" Tally="212" />
+    <Item Id="3417" Name="沙漠幽魂旗" Tally="213" />
+    <Item Id="3418" Name="蛇蜥怪旗" Tally="214" />
     <Item Id="3419" Name="Ravager Scorpion Banner" Tally="215" />
-    <Item Id="3420" Name="Stargazer Banner" Tally="216" />
-    <Item Id="3421" Name="Milkyway Weaver Banner" Tally="217" />
-    <Item Id="3422" Name="Flow Invader Banner" Tally="218" />
-    <Item Id="3423" Name="Twinkle Popper Banner" Tally="219" />
-    <Item Id="3424" Name="Small Star Cell Banner" Tally="220" />
-    <Item Id="3425" Name="Star Cell Banner" Tally="221" />
-    <Item Id="3426" Name="Corite Banner" Tally="222" />
-    <Item Id="3427" Name="Sroller Banner" Tally="223" />
-    <Item Id="3428" Name="Crawltipede Banner" Tally="224" />
-    <Item Id="3429" Name="Drakomire Rider Banner" Tally="225" />
-    <Item Id="3430" Name="Drakomire Banner" Tally="226" />
-    <Item Id="3431" Name="Selenian Banner" Tally="227" />
-    <Item Id="3432" Name="Predictor Banner" Tally="228" />
-    <Item Id="3433" Name="Brain Suckler Banner" Tally="229" />
-    <Item Id="3434" Name="Nebula Floater Banner" Tally="230" />
-    <Item Id="3435" Name="Evolution Beast Banner" Tally="231" />
-    <Item Id="3436" Name="Alien Larva Banner" Tally="232" />
-    <Item Id="3437" Name="Alien Queen Banner" Tally="233" />
-    <Item Id="3438" Name="Alien Hornet Banner" Tally="234" />
-    <Item Id="3439" Name="Vortexian Banner" Tally="235" />
-    <Item Id="3440" Name="Storm Diver Banner" Tally="236" />
-    <Item Id="3441" Name="Pirate Captain Banner" Tally="237" />
-    <Item Id="3442" Name="Pirate Deadeye Banner" Tally="238" />
-    <Item Id="3443" Name="Pirate Corsair Banner" Tally="239" />
-    <Item Id="3444" Name="Pirate Crossbower Banner" Tally="240" />
-    <Item Id="3445" Name="Martian Walker Banner" Tally="241" />
-    <Item Id="3446" Name="Red Devil Banner" Tally="242" />
-    <Item Id="3447" Name="Pink Jellyfish Banner" Tally="243" />
-    <Item Id="3448" Name="Green Jellyfish Banner" Tally="244" />
-    <Item Id="3449" Name="Dark Mummy Banner" Tally="245" />
-    <Item Id="3450" Name="Light Mummy Banner" Tally="246" />
-    <Item Id="3451" Name="Angry Bones Banner" Tally="247" />
-    <Item Id="3452" Name="Ice Tortoise Banner" Tally="248" />
-    <Item Id="3453" Name="Damage Booster" />
-    <Item Id="3454" Name="Life Booster" />
-    <Item Id="3455" Name="Mana Booster" />
-    <Item Id="3456" Name="Vortex Fragment" />
-    <Item Id="3457" Name="Nebula Fragment" />
-    <Item Id="3458" Name="Solar Fragment" />
-    <Item Id="3459" Name="Stardust Fragment" />
-    <Item Id="3460" Name="Luminite" />
-    <Item Id="3461" Name="Luminite Brick" />
-    <Item Id="3462" Name="Stardust Axe" />
-    <Item Id="3463" Name="Stardust Chainsaw" />
-    <Item Id="3464" Name="Stardust Drill" />
-    <Item Id="3465" Name="Stardust Hammer" />
-    <Item Id="3466" Name="Stardust Pickaxe" />
-    <Item Id="3467" Name="Luminite Bar" />
-    <Item Id="3468" Name="Solar Wings" />
-    <Item Id="3469" Name="Vortex Booster" />
-    <Item Id="3470" Name="Nebula Mantle" />
-    <Item Id="3471" Name="Stardust Wings" />
-    <Item Id="3472" Name="Luminite Brick Wall" />
-    <Item Id="3473" Name="Solar Eruption" Rack="true" />
-    <Item Id="3474" Name="Stardust Cell Staff" Rack="true" />
-    <Item Id="3475" Name="Vortex Beater" Rack="true" />
-    <Item Id="3476" Name="Nebula Arcanum" Rack="true" />
-    <Item Id="3477" Name="Blood Water" Rack="true" />
-    <Item Id="3478" Name="Wedding Veil" Head="190" />
-    <Item Id="3479" Name="Wedding Dress" Body="191" />
-    <Item Id="3480" Name="Platinum Bow" Rack="true" />
-    <Item Id="3481" Name="Platinum Hammer" Scale="1.275" Rack="true" />
-    <Item Id="3482" Name="Platinum Axe" Scale="1.175" Rack="true" />
-    <Item Id="3483" Name="Platinum Shortsword" Scale="0.975" Rack="true" />
-    <Item Id="3484" Name="Platinum Broadsword" Scale="1.075" Rack="true" />
-    <Item Id="3485" Name="Platinum Pickaxe" Scale="1.05" Rack="true" />
-    <Item Id="3486" Name="Tungsten Bow" Rack="true" />
-    <Item Id="3487" Name="Tungsten Hammer" Scale="1.25" Rack="true" />
-    <Item Id="3488" Name="Tungsten Axe" Scale="1.15" Rack="true" />
-    <Item Id="3489" Name="Tungsten Shortsword" Scale="0.95" Rack="true" />
-    <Item Id="3490" Name="Tungsten Broadsword" Scale="1.025" Rack="true" />
-    <Item Id="3491" Name="Tungsten Pickaxe" Scale="1.05" Rack="true" />
-    <Item Id="3492" Name="Lead Bow" Rack="true" />
-    <Item Id="3493" Name="Lead Hammer" Scale="1.225" Rack="true" />
-    <Item Id="3494" Name="Lead Axe" Scale="1.125" Rack="true" />
-    <Item Id="3495" Name="Lead Shortsword" Scale="0.925" Rack="true" />
-    <Item Id="3496" Name="Lead Broadsword" Rack="true" />
-    <Item Id="3497" Name="Lead Pickaxe" Scale="1.025" Rack="true" />
-    <Item Id="3498" Name="Tin Bow" Rack="true" />
-    <Item Id="3499" Name="Tin Hammer" Scale="1.15" Rack="true" />
-    <Item Id="3500" Name="Tin Axe" Scale="1.05" Rack="true" />
-    <Item Id="3501" Name="Tin Shortsword" Scale="0.85" Rack="true" />
-    <Item Id="3502" Name="Tin Broadsword" Rack="true" />
-    <Item Id="3503" Name="Tin Pickaxe" Scale="0.95" Rack="true" />
-    <Item Id="3504" Name="Copper Bow" Rack="true" />
-    <Item Id="3505" Name="Copper Hammer" Scale="1.1" Rack="true" />
-    <Item Id="3506" Name="Copper Axe" Rack="true" />
-    <Item Id="3507" Name="Copper Shortsword" Scale="0.8" Rack="true" />
-    <Item Id="3508" Name="Copper Broadsword" Rack="true" />
-    <Item Id="3509" Name="Copper Pickaxe" Scale="0.9" Rack="true" />
-    <Item Id="3510" Name="Silver Bow" Rack="true" />
-    <Item Id="3511" Name="Silver Hammer" Scale="1.25" Rack="true" />
-    <Item Id="3512" Name="Silver Axe" Scale="1.15" Rack="true" />
-    <Item Id="3513" Name="Silver Shortsword" Scale="0.95" Rack="true" />
-    <Item Id="3514" Name="Silver Broadsword" Rack="true" />
-    <Item Id="3515" Name="Silver Pickaxe" Scale="1.05" Rack="true" />
-    <Item Id="3516" Name="Gold Bow" Rack="true" />
-    <Item Id="3517" Name="Gold Hammer" Scale="1.25" Rack="true" />
-    <Item Id="3518" Name="Gold Axe" Scale="1.15" Rack="true" />
-    <Item Id="3519" Name="Gold Shortsword" Scale="0.95" Rack="true" />
-    <Item Id="3520" Name="Gold Broadsword" Scale="1.05" Rack="true" />
-    <Item Id="3521" Name="Gold Pickaxe" Scale="1.05" Rack="true" />
-    <Item Id="3522" Name="Solar Flare Hamaxe" Rack="true" />
-    <Item Id="3523" Name="Vortex Hamaxe" Rack="true" />
-    <Item Id="3524" Name="Nebula Hamaxe" Rack="true" />
-    <Item Id="3525" Name="Stardust Hamaxe" Rack="true" />
-    <Item Id="3526" Name="Solar Dye" />
-    <Item Id="3527" Name="Nebula Dye" />
-    <Item Id="3528" Name="Vortex Dye" />
-    <Item Id="3529" Name="Stardust Dye" />
-    <Item Id="3530" Name="Void Dye" />
-    <Item Id="3531" Name="Stardust Dragon Staff" Rack="true" />
-    <Item Id="3532" Name="Bacon" />
-    <Item Id="3533" Name="Shifting Sands Dye" />
-    <Item Id="3534" Name="Mirage Dye" />
-    <Item Id="3535" Name="Shifting Pearlsands Dye" />
-    <Item Id="3536" Name="Vortex Monolith" />
-    <Item Id="3537" Name="Nebula Monolith" />
-    <Item Id="3538" Name="Stardust Monolith" />
-    <Item Id="3539" Name="Solar Monolith" />
-    <Item Id="3540" Name="Phantasm" Rack="true" />
-    <Item Id="3541" Name="Last Prism" Rack="true" />
-    <Item Id="3542" Name="Nebula Blaze" Rack="true" />
-    <Item Id="3543" Name="Daybreak" Rack="true" />
-    <Item Id="3544" Name="Super Healing Potion" />
-    <Item Id="3545" Name="Detonator" />
-    <Item Id="3546" Name="Celebration" Rack="true" />
-    <Item Id="3547" Name="Bouncy Dynamite" />
-    <Item Id="3548" Name="Happy Grenade" Rack="true" />
-    <Item Id="3549" Name="Ancient Manipulator" />
-    <Item Id="3550" Name="Flame and Silver Dye" />
-    <Item Id="3551" Name="Green Flame and Silver Dye" />
-    <Item Id="3552" Name="Blue Flame and Silver Dye" />
-    <Item Id="3553" Name="Reflective Copper Dye" />
-    <Item Id="3554" Name="Reflective Obsidian Dye" />
-    <Item Id="3555" Name="Reflective Metal Dye" />
-    <Item Id="3556" Name="Midnight Rainbow Dye" />
-    <Item Id="3557" Name="Black and White Dye" />
-    <Item Id="3558" Name="Bright Silver Dye" />
-    <Item Id="3559" Name="Silver and Black Dye" />
-    <Item Id="3560" Name="Red Acid Dye" />
-    <Item Id="3561" Name="Gel Dye" />
-    <Item Id="3562" Name="Pink Gel Dye" />
-    <Item Id="3563" Name="Red Squirrel" />
-    <Item Id="3564" Name="Gold Squirrel" />
-    <Item Id="3565" Name="Red Squirrel Cage" />
-    <Item Id="3566" Name="Gold Squirrel Cage" />
-    <Item Id="3567" Name="Luminite Bullet" Rack="true" />
-    <Item Id="3568" Name="Luminite Arrow" Rack="true" />
-    <Item Id="3569" Name="Lunar Portal Staff" Rack="true" />
-    <Item Id="3570" Name="Lunar Flare" Rack="true" />
-    <Item Id="3571" Name="Rainbow Crystal Staff" Rack="true" />
-    <Item Id="3572" Name="Lunar Hook" />
-    <Item Id="3573" Name="Solar Fragment Block" />
-    <Item Id="3574" Name="Vortex Fragment Block" />
-    <Item Id="3575" Name="Nebula Fragment Block" />
-    <Item Id="3576" Name="Stardust Fragment Block" />
-    <Item Id="3577" Name="Suspicious Looking Tentacle" />
-    <Item Id="3578" Name="Yoraiz0r's Uniform" Body="192" />
-    <Item Id="3579" Name="Yoraiz0r's Skirt" Legs="132" />
-    <Item Id="3580" Name="Yoraiz0r's Spell" />
-    <Item Id="3581" Name="Yoraiz0r's Scowl" />
-    <Item Id="3582" Name="Jim's Wings" />
-    <Item Id="3583" Name="Yoraiz0r's Recolored Goggles" Head="191" />
-    <Item Id="3584" Name="Living Leaf Wall" />
-    <Item Id="3585" Name="Skiphs's Mask" Head="192" />
-    <Item Id="3586" Name="Skiphs's Skin" Body="193" />
-    <Item Id="3587" Name="Skiphs's Bear Butt" Legs="133" />
-    <Item Id="3588" Name="Skiphs's Paws" />
-    <Item Id="3589" Name="Loki's Helmet" Head="193" />
-    <Item Id="3590" Name="Loki's Breastplate" Body="194" />
-    <Item Id="3591" Name="Loki's Greaves" Legs="134" />
-    <Item Id="3592" Name="Loki's Wings" />
-    <Item Id="3593" Name="Sand Slime Banner" Tally="249" />
-    <Item Id="3594" Name="Sea Snail Banner" Tally="250" />
-    <Item Id="3595" Name="Moon Lord Trophy" />
-    <Item Id="3596" Name="Not a Kid, nor a Squid" />
-    <Item Id="3597" Name="Burning Hades Dye" />
-    <Item Id="3598" Name="Grim Dye" />
-    <Item Id="3599" Name="Loki's Dye" />
-    <Item Id="3600" Name="Shadowflame Hades Dye" />
-    <Item Id="3601" Name="Celestial Sigil" />
-    <Item Id="3602" Name="Logic Gate Lamp (Off)" />
-    <Item Id="3603" Name="Logic Gate (AND)" />
-    <Item Id="3604" Name="Logic Gate (OR)" />
-    <Item Id="3605" Name="Logic Gate (NAND)" />
-    <Item Id="3606" Name="Logic Gate (NOR)" />
-    <Item Id="3607" Name="Logic Gate (XOR)" />
-    <Item Id="3608" Name="Logic Gate (NXOR)" />
-    <Item Id="3609" Name="Conveyor Belt (Clockwise)" />
-    <Item Id="3610" Name="Conveyor Belt (Counter Clockwise)" />
-    <Item Id="3611" Name="The Grand Design" />
-    <Item Id="3612" Name="Yellow Wrench" />
-    <Item Id="3613" Name="Logic Sensor (Day)" />
-    <Item Id="3614" Name="Logic Sensor (Night)" />
-    <Item Id="3615" Name="Logic Sensor (Player Above)" />
-    <Item Id="3616" Name="Junction Box" />
-    <Item Id="3617" Name="Announcement Box" />
-    <Item Id="3618" Name="Logic Gate Lamp (On)" />
-    <Item Id="3619" Name="Mechanical Lens" />
-    <Item Id="3620" Name="Actuation Rod" />
-    <Item Id="3621" Name="Red Team Block" />
-    <Item Id="3622" Name="Red Team Platform" />
-    <Item Id="3623" Name="Static Hook" />
-    <Item Id="3624" Name="Presserator" />
-    <Item Id="3625" Name="Multicolor Wrench" />
-    <Item Id="3626" Name="Pink Weighted Pressure Plate" />
-    <Item Id="3627" Name="Engineering Helmet" Head="194" />
-    <Item Id="3628" Name="Companion Cube" />
-    <Item Id="3629" Name="Wire Bulb" />
-    <Item Id="3630" Name="Orange Weighted Pressure Plate" />
-    <Item Id="3631" Name="Purple Weighted Pressure Plate" />
-    <Item Id="3632" Name="Cyan Weighted Pressure Plate" />
-    <Item Id="3633" Name="Green Team Block" />
-    <Item Id="3634" Name="Blue Team Block" />
-    <Item Id="3635" Name="Yellow Team Block" />
-    <Item Id="3636" Name="Pink Team Block" />
-    <Item Id="3637" Name="White Team Block" />
-    <Item Id="3638" Name="Green Team Platform" />
-    <Item Id="3639" Name="Blue Team Platform" />
-    <Item Id="3640" Name="Yellow Team Platform" />
-    <Item Id="3641" Name="Pink Team Platform" />
-    <Item Id="3642" Name="White Team Platform" />
-    <Item Id="3643" Name="Large Amber" />
-    <Item Id="3644" Name="Ruby Gem Lock" />
-    <Item Id="3645" Name="Sapphire Gem Lock" />
-    <Item Id="3646" Name="Emerald Gem Lock" />
-    <Item Id="3647" Name="Topaz Gem Lock" />
-    <Item Id="3648" Name="Amethyst Gem Lock" />
-    <Item Id="3649" Name="Diamond Gem Lock" />
-    <Item Id="3650" Name="Amber Gem Lock" />
-    <Item Id="3651" Name="Squirrel Statue" />
-    <Item Id="3652" Name="Butterfly Statue" />
-    <Item Id="3653" Name="Worm Statue" />
-    <Item Id="3654" Name="Firefly Statue" />
-    <Item Id="3655" Name="Scorpion Statue" />
-    <Item Id="3656" Name="Snail Statue" />
-    <Item Id="3657" Name="Grasshopper Statue" />
-    <Item Id="3658" Name="Mouse Statue" />
-    <Item Id="3659" Name="Duck Statue" />
-    <Item Id="3660" Name="Penguin Statue" />
-    <Item Id="3661" Name="Frog Statue" />
-    <Item Id="3662" Name="Buggy Statue" />
-    <Item Id="3663" Name="Logic Gate Lamp (Faulty)" />
-    <Item Id="3664" Name="Portal Gun Station" />
-    <Item Id="3665" Name="Trapped Chest" />
-    <Item Id="3666" Name="Trapped Gold Chest" />
-    <Item Id="3667" Name="Trapped Shadow Chest" />
-    <Item Id="3668" Name="Trapped Ebonwood Chest" />
-    <Item Id="3669" Name="Trapped Rich Mahogany Chest" />
-    <Item Id="3670" Name="Trapped Pearlwood Chest" />
-    <Item Id="3671" Name="Trapped Ivy Chest" />
-    <Item Id="3672" Name="Trapped Ice Chest" />
-    <Item Id="3673" Name="Trapped Living Wood Chest" />
-    <Item Id="3674" Name="Trapped Skyware Chest" />
-    <Item Id="3675" Name="Trapped Shadewood Chest" />
-    <Item Id="3676" Name="Trapped Web Covered Chest" />
-    <Item Id="3677" Name="Trapped Lihzahrd Chest" />
-    <Item Id="3678" Name="Trapped Water Chest" />
-    <Item Id="3679" Name="Trapped Jungle Chest" />
-    <Item Id="3680" Name="Trapped Corruption Chest" />
-    <Item Id="3681" Name="Trapped Crimson Chest" />
-    <Item Id="3682" Name="Trapped Hallowed Chest" />
-    <Item Id="3683" Name="Trapped Frozen Chest" />
-    <Item Id="3684" Name="Trapped Dynasty Chest" />
-    <Item Id="3685" Name="Trapped Honey Chest" />
-    <Item Id="3686" Name="Trapped Steampunk Chest" />
-    <Item Id="3687" Name="Trapped Palm Wood Chest" />
-    <Item Id="3688" Name="Trapped Mushroom Chest" />
-    <Item Id="3689" Name="Trapped Boreal Wood Chest" />
-    <Item Id="3690" Name="Trapped Slime Chest" />
-    <Item Id="3691" Name="Trapped Green Dungeon Chest" />
-    <Item Id="3692" Name="Trapped Pink Dungeon Chest" />
-    <Item Id="3693" Name="Trapped Blue Dungeon Chest" />
-    <Item Id="3694" Name="Trapped Bone Chest" />
-    <Item Id="3695" Name="Trapped Cactus Chest" />
-    <Item Id="3696" Name="Trapped Flesh Chest" />
-    <Item Id="3697" Name="Trapped Obsidian Chest" />
-    <Item Id="3698" Name="Trapped Pumpkin Chest" />
-    <Item Id="3699" Name="Trapped Spooky Chest" />
-    <Item Id="3700" Name="Trapped Glass Chest" />
-    <Item Id="3701" Name="Trapped Martian Chest" />
-    <Item Id="3702" Name="Trapped Meteroite Chest" />
-    <Item Id="3703" Name="Trapped Granite Chest" />
-    <Item Id="3704" Name="Trapped Marble Chest" />
+    <Item Id="3420" Name="观星怪旗" Tally="216" />
+    <Item Id="3421" Name="银河织妖旗" Tally="217" />
+    <Item Id="3422" Name="液体入侵怪旗" Tally="218" />
+    <Item Id="3423" Name="闪耀炮手旗" Tally="219" />
+    <Item Id="3424" Name="小星细胞法杖旗" Tally="220" />
+    <Item Id="3425" Name="星细胞法杖旗" Tally="221" />
+    <Item Id="3426" Name="流星火怪旗" Tally="222" />
+    <Item Id="3427" Name="火滚怪旗" Tally="223" />
+    <Item Id="3428" Name="千足蜈蚣旗" Tally="224" />
+    <Item Id="3429" Name="火龙怪骑士旗" Tally="225" />
+    <Item Id="3430" Name="火龙怪旗" Tally="226" />
+    <Item Id="3431" Name="火月怪旗" Tally="227" />
+    <Item Id="3432" Name="预言帝旗" Tally="228" />
+    <Item Id="3433" Name="吮脑怪旗" Tally="229" />
+    <Item Id="3434" Name="星云浮怪旗" Tally="230" />
+    <Item Id="3435" Name="进化兽旗" Tally="231" />
+    <Item Id="3436" Name="异星幼虫旗" Tally="232" />
+    <Item Id="3437" Name="异星蜂王旗" Tally="233" />
+    <Item Id="3438" Name="异星黄蜂旗" Tally="234" />
+    <Item Id="3439" Name="星旋怪旗" Tally="235" />
+    <Item Id="3440" Name="漩泥怪旗" Tally="236" />
+    <Item Id="3441" Name="海盗船长旗" Tally="237" />
+    <Item Id="3442" Name="海盗神射手旗" Tally="238" />
+    <Item Id="3443" Name="私船海盗旗" Tally="239" />
+    <Item Id="3444" Name="海盗弩手旗" Tally="240" />
+    <Item Id="3445" Name="火星走妖旗" Tally="241" />
+    <Item Id="3446" Name="红魔鬼旗" Tally="242" />
+    <Item Id="3447" Name="粉水母旗" Tally="243" />
+    <Item Id="3448" Name="绿水母旗" Tally="244" />
+    <Item Id="3449" Name="暗黑木乃伊旗" Tally="245" />
+    <Item Id="3450" Name="光明木乃伊旗" Tally="246" />
+    <Item Id="3451" Name="愤怒骷髅怪旗" Tally="247" />
+    <Item Id="3452" Name="冰雪陆龟旗" Tally="248" />
+    <Item Id="3453" Name="伤害强化焰" />
+    <Item Id="3454" Name="生命强化焰" />
+    <Item Id="3455" Name="魔力强化焰" />
+    <Item Id="3456" Name="星旋碎片" />
+    <Item Id="3457" Name="星云碎片" />
+    <Item Id="3458" Name="日耀碎片" />
+    <Item Id="3459" Name="星尘碎片" />
+    <Item Id="3460" Name="夜明矿" />
+    <Item Id="3461" Name="夜明砖" />
+    <Item Id="3462" Name="星尘斧" />
+    <Item Id="3463" Name="星尘链锯" />
+    <Item Id="3464" Name="星尘钻头" />
+    <Item Id="3465" Name="星尘锤" />
+    <Item Id="3466" Name="星尘镐" />
+    <Item Id="3467" Name="夜明锭" />
+    <Item Id="3468" Name="日耀之翼" />
+    <Item Id="3469" Name="星旋强化翼" />
+    <Item Id="3470" Name="星云斗篷" />
+    <Item Id="3471" Name="星尘之翼" />
+    <Item Id="3472" Name="夜明砖墙" />
+    <Item Id="3473" Name="日耀喷发剑" Rack="true" />
+    <Item Id="3474" Name="星尘细胞法杖" Rack="true" />
+    <Item Id="3475" Name="星旋机枪" Rack="true" />
+    <Item Id="3476" Name="星云奥秘" Rack="true" />
+    <Item Id="3477" Name="血水" Rack="true" />
+    <Item Id="3478" Name="面纱" Head="190" />
+    <Item Id="3479" Name="婚裙" Body="191" />
+    <Item Id="3480" Name="铂金弓" Rack="true" />
+    <Item Id="3481" Name="铂金锤" Scale="1.275" Rack="true" />
+    <Item Id="3482" Name="铂金斧" Scale="1.175" Rack="true" />
+    <Item Id="3483" Name="铂金短剑" Scale="0.975" Rack="true" />
+    <Item Id="3484" Name="铂金宽剑" Scale="1.075" Rack="true" />
+    <Item Id="3485" Name="铂金镐" Scale="1.05" Rack="true" />
+    <Item Id="3486" Name="钨弓" Rack="true" />
+    <Item Id="3487" Name="钨锤" Scale="1.25" Rack="true" />
+    <Item Id="3488" Name="钨斧" Scale="1.15" Rack="true" />
+    <Item Id="3489" Name="钨短剑" Scale="0.95" Rack="true" />
+    <Item Id="3490" Name="钨宽剑" Scale="1.025" Rack="true" />
+    <Item Id="3491" Name="钨镐" Scale="1.05" Rack="true" />
+    <Item Id="3492" Name="铅弓" Rack="true" />
+    <Item Id="3493" Name="铅锤" Scale="1.225" Rack="true" />
+    <Item Id="3494" Name="铅斧" Scale="1.125" Rack="true" />
+    <Item Id="3495" Name="铅短剑" Scale="0.925" Rack="true" />
+    <Item Id="3496" Name="铅宽剑" Rack="true" />
+    <Item Id="3497" Name="铅镐" Scale="1.025" Rack="true" />
+    <Item Id="3498" Name="锡弓" Rack="true" />
+    <Item Id="3499" Name="锡锤" Scale="1.15" Rack="true" />
+    <Item Id="3500" Name="锡斧" Scale="1.05" Rack="true" />
+    <Item Id="3501" Name="锡短剑" Scale="0.85" Rack="true" />
+    <Item Id="3502" Name="锡宽剑" Rack="true" />
+    <Item Id="3503" Name="锡镐" Scale="0.95" Rack="true" />
+    <Item Id="3504" Name="铜弓" Rack="true" />
+    <Item Id="3505" Name="铜锤" Scale="1.1" Rack="true" />
+    <Item Id="3506" Name="铜斧" Rack="true" />
+    <Item Id="3507" Name="铜短剑" Scale="0.8" Rack="true" />
+    <Item Id="3508" Name="铜阔剑" Rack="true" />
+    <Item Id="3509" Name="铜镐" Scale="0.9" Rack="true" />
+    <Item Id="3510" Name="银弓" Rack="true" />
+    <Item Id="3511" Name="银锤" Scale="1.25" Rack="true" />
+    <Item Id="3512" Name="银斧" Scale="1.15" Rack="true" />
+    <Item Id="3513" Name="银短剑" Scale="0.95" Rack="true" />
+    <Item Id="3514" Name="银阔剑" Rack="true" />
+    <Item Id="3515" Name="银镐" Scale="1.05" Rack="true" />
+    <Item Id="3516" Name="金弓" Rack="true" />
+    <Item Id="3517" Name="金锤" Scale="1.25" Rack="true" />
+    <Item Id="3518" Name="金斧" Scale="1.15" Rack="true" />
+    <Item Id="3519" Name="金短剑" Scale="0.95" Rack="true" />
+    <Item Id="3520" Name="金阔剑" Scale="1.05" Rack="true" />
+    <Item Id="3521" Name="金镐" Scale="1.05" Rack="true" />
+    <Item Id="3522" Name="耀斑锤斧" Rack="true" />
+    <Item Id="3523" Name="星旋锤斧" Rack="true" />
+    <Item Id="3524" Name="星云锤斧" Rack="true" />
+    <Item Id="3525" Name="星尘锤斧" Rack="true" />
+    <Item Id="3526" Name="日耀染料" />
+    <Item Id="3527" Name="星云燃料" />
+    <Item Id="3528" Name="星旋染料" />
+    <Item Id="3529" Name="星尘染料" />
+    <Item Id="3530" Name="缥缈染料" />
+    <Item Id="3531" Name="星尘之龙法杖" Rack="true" />
+    <Item Id="3532" Name="培根" />
+    <Item Id="3533" Name="流沙染料" />
+    <Item Id="3534" Name="幻象染料" />
+    <Item Id="3535" Name="珍珠流沙染料" />
+    <Item Id="3536" Name="星旋天塔柱" />
+    <Item Id="3537" Name="星云天塔柱" />
+    <Item Id="3538" Name="星尘天塔柱" />
+    <Item Id="3539" Name="日耀天塔柱" />
+    <Item Id="3540" Name="幻影弓" Rack="true" />
+    <Item Id="3541" Name="终极棱镜" Rack="true" />
+    <Item Id="3542" Name="星云烈焰" Rack="true" />
+    <Item Id="3543" Name="破晓之光" Rack="true" />
+    <Item Id="3544" Name="超级治疗药水" />
+    <Item Id="3545" Name="引爆器" />
+    <Item Id="3546" Name="喜庆弹射器" Rack="true" />
+    <Item Id="3547" Name="弹力雷管" />
+    <Item Id="3548" Name="快乐手榴弹" Rack="true" />
+    <Item Id="3549" Name="远古操纵机" />
+    <Item Id="3550" Name="红焰银染料" />
+    <Item Id="3551" Name="绿焰银染料" />
+    <Item Id="3552" Name="蓝焰银染料" />
+    <Item Id="3553" Name="反光铜染料" />
+    <Item Id="3554" Name="反光黑曜石染料" />
+    <Item Id="3555" Name="反光金属染料" />
+    <Item Id="3556" Name="午夜彩虹染料" />
+    <Item Id="3557" Name="黑白染料" />
+    <Item Id="3558" Name="淡银染料" />
+    <Item Id="3559" Name="银黑染料" />
+    <Item Id="3560" Name="红酸性染料" />
+    <Item Id="3561" Name="凝胶染料" />
+    <Item Id="3562" Name="粉凝胶染料" />
+    <Item Id="3563" Name="红松鼠" />
+    <Item Id="3564" Name="金松鼠" />
+    <Item Id="3565" Name="红松鼠笼" />
+    <Item Id="3566" Name="金松鼠笼" />
+    <Item Id="3567" Name="夜明弹" Rack="true" />
+    <Item Id="3568" Name="夜明箭" Rack="true" />
+    <Item Id="3569" Name="月亮传送门法杖" Rack="true" />
+    <Item Id="3570" Name="月耀" Rack="true" />
+    <Item Id="3571" Name="七彩水晶法杖" Rack="true" />
+    <Item Id="3572" Name="月钩" />
+    <Item Id="3573" Name="日耀碎片块" />
+    <Item Id="3574" Name="星旋碎片块" />
+    <Item Id="3575" Name="星云碎片块" />
+    <Item Id="3576" Name="星尘碎片块" />
+    <Item Id="3577" Name="可疑触手" />
+    <Item Id="3578" Name="Yoraiz0r的制服" Body="192" />
+    <Item Id="3579" Name="Yoraiz0r的裙" Legs="132" />
+    <Item Id="3580" Name="Yoraiz0r的魔法" />
+    <Item Id="3581" Name="Yoraiz0r的怒容" />
+    <Item Id="3582" Name="Jim的翅膀" />
+    <Item Id="3583" Name="Yoraiz0r的染色护目镜" Head="191" />
+    <Item Id="3584" Name="生命树叶墙" />
+    <Item Id="3585" Name="Skiphs的面具" Head="192" />
+    <Item Id="3586" Name="Skiphs的皮肤" Body="193" />
+    <Item Id="3587" Name="Skiphs的熊裤" Legs="133" />
+    <Item Id="3588" Name="Skiphs的爪子" />
+    <Item Id="3589" Name="Loki的头盔" Head="193" />
+    <Item Id="3590" Name="Loki的胸甲" Body="194" />
+    <Item Id="3591" Name="Loki的护胫" Legs="134" />
+    <Item Id="3592" Name="Loki的翅膀" />
+    <Item Id="3593" Name="沙史莱姆旗" Tally="249" />
+    <Item Id="3594" Name="海蜗牛旗" Tally="250" />
+    <Item Id="3595" Name="月亮领主纪念章" />
+    <Item Id="3596" Name="不是小孩，也不是乌贼" />
+    <Item Id="3597" Name="烈焰冥王染料" />
+    <Item Id="3598" Name="恐怖染料" />
+    <Item Id="3599" Name="Loki的染料" />
+    <Item Id="3600" Name="暗影焰冥王染料" />
+    <Item Id="3601" Name="天界符" />
+    <Item Id="3602" Name="逻辑门灯（关）" />
+    <Item Id="3603" Name="逻辑门（与）" />
+    <Item Id="3604" Name="逻辑门（或）" />
+    <Item Id="3605" Name="逻辑门（与非）" />
+    <Item Id="3606" Name="逻辑门（或非）" />
+    <Item Id="3607" Name="逻辑门（异或）" />
+    <Item Id="3608" Name="逻辑门（同或）" />
+    <Item Id="3609" Name="传送带（顺时针）" />
+    <Item Id="3610" Name="传送带（逆时针）" />
+    <Item Id="3611" Name="精密线控仪" />
+    <Item Id="3612" Name="黄扳手" />
+    <Item Id="3613" Name="逻辑感应器（昼）" />
+    <Item Id="3614" Name="逻辑感应器（夜）" />
+    <Item Id="3615" Name="逻辑感应器（玩家出入上方）" />
+    <Item Id="3616" Name="分线盒" />
+    <Item Id="3617" Name="广播盒" />
+    <Item Id="3618" Name="逻辑门灯（开）" />
+    <Item Id="3619" Name="机械晶状体" />
+    <Item Id="3620" Name="制动魔杖" />
+    <Item Id="3621" Name="红团队块" />
+    <Item Id="3622" Name="红团队平台" />
+    <Item Id="3623" Name="静止钩" />
+    <Item Id="3624" Name="自动安放器" />
+    <Item Id="3625" Name="五彩扳手" />
+    <Item Id="3626" Name="粉色加重压力板" />
+    <Item Id="3627" Name="工程头盔" Head="194" />
+    <Item Id="3628" Name="同伴方块" />
+    <Item Id="3629" Name="彩线灯泡" />
+    <Item Id="3630" Name="橙色加重压力板" />
+    <Item Id="3631" Name="紫色加重压力板" />
+    <Item Id="3632" Name="青色加重压力板" />
+    <Item Id="3633" Name="绿团队块" />
+    <Item Id="3634" Name="蓝团队块" />
+    <Item Id="3635" Name="黄团队块" />
+    <Item Id="3636" Name="粉团队块" />
+    <Item Id="3637" Name="白团队块" />
+    <Item Id="3638" Name="绿团队平台" />
+    <Item Id="3639" Name="蓝团队平台" />
+    <Item Id="3640" Name="黄团队平台" />
+    <Item Id="3641" Name="粉团队平台" />
+    <Item Id="3642" Name="白团队平台" />
+    <Item Id="3643" Name="大琥珀" />
+    <Item Id="3644" Name="红玉宝石锁" />
+    <Item Id="3645" Name="蓝玉宝石锁" />
+    <Item Id="3646" Name="翡翠宝石锁" />
+    <Item Id="3647" Name="黄玉宝石锁" />
+    <Item Id="3648" Name="紫晶宝石锁" />
+    <Item Id="3649" Name="钻石宝石锁" />
+    <Item Id="3650" Name="琥珀宝石锁" />
+    <Item Id="3651" Name="松鼠雕像" />
+    <Item Id="3652" Name="蝴蝶雕像" />
+    <Item Id="3653" Name="蠕虫雕像" />
+    <Item Id="3654" Name="萤火虫雕像" />
+    <Item Id="3655" Name="蝎子雕像" />
+    <Item Id="3656" Name="蜗牛雕像" />
+    <Item Id="3657" Name="蚱蜢雕像" />
+    <Item Id="3658" Name="老鼠雕像" />
+    <Item Id="3659" Name="小鸭雕像" />
+    <Item Id="3660" Name="企鹅雕像" />
+    <Item Id="3661" Name="青蛙雕像" />
+    <Item Id="3662" Name="蚜虫雕像" />
+    <Item Id="3663" Name="逻辑门灯（故障）" />
+    <Item Id="3664" Name="传送枪站" />
+    <Item Id="3665" Name="受困宝箱" />
+    <Item Id="3666" Name="受困金箱" />
+    <Item Id="3667" Name="受困暗影箱" />
+    <Item Id="3668" Name="受困乌木箱" />
+    <Item Id="3669" Name="受困红木箱" />
+    <Item Id="3670" Name="受困珍珠木箱" />
+    <Item Id="3671" Name="受困常春藤箱" />
+    <Item Id="3672" Name="受困冰雪箱" />
+    <Item Id="3673" Name="受困生命木箱" />
+    <Item Id="3674" Name="受困天域箱" />
+    <Item Id="3675" Name="受困暗影木箱" />
+    <Item Id="3676" Name="受困蛛丝箱" />
+    <Item Id="3677" Name="受困丛林蜥蜴箱" />
+    <Item Id="3678" Name="受困水中箱" />
+    <Item Id="3679" Name="受困丛林箱" />
+    <Item Id="3680" Name="受困腐化箱" />
+    <Item Id="3681" Name="受困猩红箱" />
+    <Item Id="3682" Name="受困神圣箱" />
+    <Item Id="3683" Name="受困冰冻箱" />
+    <Item Id="3684" Name="受困王朝箱" />
+    <Item Id="3685" Name="受困蜂蜜箱" />
+    <Item Id="3686" Name="受困蒸汽朋克箱" />
+    <Item Id="3687" Name="受困棕榈木箱" />
+    <Item Id="3688" Name="受困蘑菇箱" />
+    <Item Id="3689" Name="受困针叶木箱" />
+    <Item Id="3690" Name="受困史莱姆箱" />
+    <Item Id="3691" Name="受困绿地牢箱" />
+    <Item Id="3692" Name="受困粉地牢箱" />
+    <Item Id="3693" Name="受困蓝地牢箱" />
+    <Item Id="3694" Name="受困骨箱" />
+    <Item Id="3695" Name="受困仙人掌箱" />
+    <Item Id="3696" Name="受困血肉箱" />
+    <Item Id="3697" Name="受困黑曜石箱" />
+    <Item Id="3698" Name="受困南瓜箱" />
+    <Item Id="3699" Name="受困阴森箱" />
+    <Item Id="3700" Name="受困玻璃箱" />
+    <Item Id="3701" Name="受困火星箱" />
+    <Item Id="3702" Name="受困陨石箱" />
+    <Item Id="3703" Name="受困花岗岩箱" />
+    <Item Id="3704" Name="受困大理石箱" />
     <Item Id="3705" Name="Trapped NewChest1" />
     <Item Id="3706" Name="Trapped NewChest2" />
-    <Item Id="3707" Name="Teal Pressure Pad" />
-    <Item Id="3708" Name="Wall Creeper Statue" />
-    <Item Id="3709" Name="Unicorn Statue" />
-    <Item Id="3710" Name="Drippler Statue" />
-    <Item Id="3711" Name="Wraith Statue" />
-    <Item Id="3712" Name="Bone Skeleton Statue" />
-    <Item Id="3713" Name="Undead Viking Statue" />
-    <Item Id="3714" Name="Medusa Statue" />
-    <Item Id="3715" Name="Harpy Statue" />
-    <Item Id="3716" Name="Pigron Statue" />
-    <Item Id="3717" Name="Hoplite Statue" />
-    <Item Id="3718" Name="Granite Golem Statue" />
-    <Item Id="3719" Name="Armed Zombie Statue" />
-    <Item Id="3720" Name="Blood Zombie Statue" />
-    <Item Id="3721" Name="Angler Tackle Bag" />
-    <Item Id="3722" Name="Geyser" />
-    <Item Id="3723" Name="Ultra Bright Campfire" />
-    <Item Id="3724" Name="Bone Campfire" />
-    <Item Id="3725" Name="Pixel Box" />
-    <Item Id="3726" Name="Liquid Sensor (Water)" />
-    <Item Id="3727" Name="Liquid Sensor (Lava)" />
-    <Item Id="3728" Name="Liquid Sensor (Honey)" />
-    <Item Id="3729" Name="Liquid Sensor (Any)" />
-    <Item Id="3730" Name="Bundled Party Balloons" />
-    <Item Id="3731" Name="Balloon Animal" />
-    <Item Id="3732" Name="Party Hat" Head="195" />
-    <Item Id="3733" Name="Silly Sunflower Petals" Head="196" />
-    <Item Id="3734" Name="Silly Sunflower Tops" Body="195" />
-    <Item Id="3735" Name="Silly Sunflower Bottoms" Legs="138" />
-    <Item Id="3736" Name="Silly Pink Balloon" />
-    <Item Id="3737" Name="Silly Purple Balloon" />
-    <Item Id="3738" Name="Silly Green Balloon" />
-    <Item Id="3739" Name="Blue Streamer" />
-    <Item Id="3740" Name="Green Streamer" />
-    <Item Id="3741" Name="Pink Streamer" />
-    <Item Id="3742" Name="Silly Balloon Machine" />
-    <Item Id="3743" Name="Silly Tied Balloon (Pink)" />
-    <Item Id="3744" Name="Silly Tied Balloon (Purple)" />
-    <Item Id="3745" Name="Silly Tied Balloon (Green)" />
-    <Item Id="3746" Name="Pigronata" />
-    <Item Id="3747" Name="Party Center" />
-    <Item Id="3748" Name="Silly Tied Bundle of Balloons" />
-    <Item Id="3749" Name="Party Present" />
-    <Item Id="3750" Name="Slice of Cake" />
-    <Item Id="3751" Name="Cog Wall" />
-    <Item Id="3752" Name="Sandfall Wall" />
-    <Item Id="3753" Name="Snowfall Wall" />
-    <Item Id="3754" Name="Sandfall" />
-    <Item Id="3755" Name="Snowfall" />
-    <Item Id="3756" Name="Snow Cloud" />
-    <Item Id="3757" Name="Pedguin's Hood" Head="197" />
-    <Item Id="3758" Name="Pedguin's Jacket" Body="196" />
-    <Item Id="3759" Name="Pedguin's Trousers" Legs="139" />
-    <Item Id="3760" Name="Silly Pink Balloon Wall" />
-    <Item Id="3761" Name="Silly Purple Balloon Wall" />
-    <Item Id="3762" Name="Silly Green Balloon Wall" />
-    <Item Id="3763" Name="0x33's Aviators" Head="198" />
-    <Item Id="3764" Name="Blue Phasesaber" Scale="1.15" Rack="true" />
-    <Item Id="3765" Name="Red Phasesaber" Scale="1.15" Rack="true" />
-    <Item Id="3766" Name="Green Phasesaber" Scale="1.15" Rack="true" />
-    <Item Id="3767" Name="Purple Phasesaber" Scale="1.15" Rack="true" />
-    <Item Id="3768" Name="White Phasesaber" Scale="1.15" Rack="true" />
-    <Item Id="3769" Name="Yellow Phasesaber" Scale="1.15" Rack="true" />
-    <Item Id="3770" Name="Djinn's Curse" Legs="140" />
-    <Item Id="3771" Name="Ancient Horn" />
-    <Item Id="3772" Name="Mandible Blade" Rack="true" />
-    <Item Id="3773" Name="Ancient Headdress" Head="199" />
-    <Item Id="3774" Name="Ancient Garments" Body="197" />
-    <Item Id="3775" Name="Ancient Slacks" Legs="141" />
-    <Item Id="3776" Name="Forbidden Mask" Head="200" />
-    <Item Id="3777" Name="Forbidden Robes" Body="198" />
-    <Item Id="3778" Name="Forbidden Treads" Legs="142" />
-    <Item Id="3779" Name="Spirit Flame" Rack="true" />
-    <Item Id="3780" Name="Sand Elemental Banner" Tally="251" />
-    <Item Id="3781" Name="Pocket Mirror" />
-    <Item Id="3782" Name="Magic Sand Dropper" />
-    <Item Id="3783" Name="Forbidden Fragment" />
-    <Item Id="3784" Name="Lamia Tail" Legs="143" />
-    <Item Id="3785" Name="Lamia Wraps" Body="199" />
-    <Item Id="3786" Name="Lamia Mask" Head="201" />
-    <Item Id="3787" Name="Sky Fracture" Rack="true" />
-    <Item Id="3788" Name="Onyx Blaster" Rack="true" />
-    <Item Id="3789" Name="Sand Shark Banner" Tally="252" />
-    <Item Id="3790" Name="Bone Biter Banner" Tally="253" />
-    <Item Id="3791" Name="Flesh Reaver Banner" Tally="254" />
-    <Item Id="3792" Name="Crystal Thresher Banner" Tally="255" />
-    <Item Id="3793" Name="Angry Tumbler Banner" Tally="256" />
-    <Item Id="3794" Name="Ancient Cloth" />
-    <Item Id="3795" Name="Desert Spirit Lamp" />
-    <Item Id="3796" Name="Music Box (Sandstorm)" />
-    <Item Id="3797" Name="Apprentice's Hat" Head="203" />
-    <Item Id="3798" Name="Apprentice's Robe" Body="200" />
-    <Item Id="3799" Name="Apprentice's Trousers" Legs="144" />
-    <Item Id="3800" Name="Squire's Great Helm" Head="204" />
-    <Item Id="3801" Name="Squire's Plating" Body="201" />
-    <Item Id="3802" Name="Squire's Greaves" Legs="145" />
-    <Item Id="3803" Name="Huntress's Wig" Head="205" />
-    <Item Id="3804" Name="Huntress's Jerkin" Body="202" />
-    <Item Id="3805" Name="Huntress's Pants" Legs="146" />
-    <Item Id="3806" Name="Monk's Bushy Brow Bald Cap" Head="206" />
-    <Item Id="3807" Name="Monk's Shirt" Body="203" />
-    <Item Id="3808" Name="Monk's Pants" Legs="148" />
-    <Item Id="3809" Name="Apprentice's Scarf" />
-    <Item Id="3810" Name="Squire's Shield" />
-    <Item Id="3811" Name="Huntress's Buckler" />
-    <Item Id="3812" Name="Monk's Belt" />
-    <Item Id="3813" Name="Defender's Forge" />
-    <Item Id="3814" Name="War Table" />
-    <Item Id="3815" Name="War Table Banner" />
-    <Item Id="3816" Name="Elder Crystal Stand" />
-    <Item Id="3817" Name="Defender Medal" />
-    <Item Id="3818" Name="Flameburst Rod" Rack="true" />
-    <Item Id="3819" Name="Flameburst Cane" Rack="true" />
-    <Item Id="3820" Name="Flameburst Staff" Rack="true" />
-    <Item Id="3821" Name="Ale Tosser" Rack="true" />
-    <Item Id="3822" Name="Etherian Mana" />
-    <Item Id="3823" Name="Brand of the Inferno" Scale="1.15" Rack="true" />
-    <Item Id="3824" Name="Ballista Rod" Rack="true" />
-    <Item Id="3825" Name="Ballista Cane" Rack="true" />
-    <Item Id="3826" Name="Ballista Staff" Rack="true" />
-    <Item Id="3827" Name="Flying Dragon" Rack="true" />
-    <Item Id="3828" Name="Elder Crystal" />
-    <Item Id="3829" Name="Lightning Aura Rod" Rack="true" />
-    <Item Id="3830" Name="Lightning Aura Cane" Rack="true" />
-    <Item Id="3831" Name="Lightning Aura Staff" Rack="true" />
-    <Item Id="3832" Name="Explosive Trap Rod" Rack="true" />
-    <Item Id="3833" Name="Explosive Trap Cane" Rack="true" />
-    <Item Id="3834" Name="Explosive Trap Staff" Rack="true" />
-    <Item Id="3835" Name="Sleepy Octopod" Rack="true" />
-    <Item Id="3836" Name="Ghastly Glaive" Rack="true" />
-    <Item Id="3837" Name="Etherian Goblin Bomber Banner" Tally="257" />
-    <Item Id="3838" Name="Etherian Goblin Banner" Tally="258" />
-    <Item Id="3839" Name="Old One's Skeleton Banner" Tally="259" />
-    <Item Id="3840" Name="Drakin Banner" Tally="260" />
-    <Item Id="3841" Name="Kobold Glider Banner" Tally="261" />
-    <Item Id="3842" Name="Kobold Banner" Tally="262" />
-    <Item Id="3843" Name="Wither Beast Banner" Tally="263" />
-    <Item Id="3844" Name="Etherian Wyvern Banner" Tally="264" />
-    <Item Id="3845" Name="Etherian Javelin Thrower Banner" Tally="265" />
-    <Item Id="3846" Name="Etherian Lightning Bug Banner" Tally="266" />
-    <Item Id="3847" Name="Ogre Mask" />
+    <Item Id="3707" Name="青绿压力垫板" />
+    <Item Id="3708" Name="爬墙蜘蛛雕像" />
+    <Item Id="3709" Name="独角兽雕像" />
+    <Item Id="3710" Name="滴滴怪雕像" />
+    <Item Id="3711" Name="幻灵雕像" />
+    <Item Id="3712" Name="骨头骷髅雕像" />
+    <Item Id="3713" Name="亡灵维京海盗雕像" />
+    <Item Id="3714" Name="蛇发女妖雕像" />
+    <Item Id="3715" Name="鸟妖雕像" />
+    <Item Id="3716" Name="猪龙雕像" />
+    <Item Id="3717" Name="装甲步兵雕像" />
+    <Item Id="3718" Name="花岗岩巨人雕像" />
+    <Item Id="3719" Name="武装僵尸雕像" />
+    <Item Id="3720" Name="血腥僵尸雕像" />
+    <Item Id="3721" Name="渔夫渔具袋" />
+    <Item Id="3722" Name="喷泉" />
+    <Item Id="3723" Name="超亮篝火" />
+    <Item Id="3724" Name="骨头篝火" />
+    <Item Id="3725" Name="像素盒" />
+    <Item Id="3726" Name="液体感应器（水）" />
+    <Item Id="3727" Name="液体感应器（熔岩）" />
+    <Item Id="3728" Name="液体感应器（蜂蜜）" />
+    <Item Id="3729" Name="液体感应器（任何）" />
+    <Item Id="3730" Name="派对气球束" />
+    <Item Id="3731" Name="气球兔兔" />
+    <Item Id="3732" Name="派对帽" Head="195" />
+    <Item Id="3733" Name="呆萌向日葵花瓣头盔" Head="196" />
+    <Item Id="3734" Name="呆萌向日葵上衣" Body="195" />
+    <Item Id="3735" Name="呆萌向日葵裤装" Legs="138" />
+    <Item Id="3736" Name="呆萌粉气球" />
+    <Item Id="3737" Name="呆萌紫气球" />
+    <Item Id="3738" Name="呆萌绿气球" />
+    <Item Id="3739" Name="蓝饰带" />
+    <Item Id="3740" Name="绿饰带" />
+    <Item Id="3741" Name="粉饰带" />
+    <Item Id="3742" Name="呆萌气球机" />
+    <Item Id="3743" Name="呆萌丝带气球（粉）" />
+    <Item Id="3744" Name="呆萌丝带气球（紫）" />
+    <Item Id="3745" Name="呆萌丝带气球（绿）" />
+    <Item Id="3746" Name="猪龙彩罐" />
+    <Item Id="3747" Name="派对中心" />
+    <Item Id="3748" Name="呆萌丝带派对气球束" />
+    <Item Id="3749" Name="派对礼物" />
+    <Item Id="3750" Name="蛋糕块" />
+    <Item Id="3751" Name="齿轮墙" />
+    <Item Id="3752" Name="沙暴墙" />
+    <Item Id="3753" Name="降雪墙" />
+    <Item Id="3754" Name="沙暴" />
+    <Item Id="3755" Name="降雪" />
+    <Item Id="3756" Name="雪云" />
+    <Item Id="3757" Name="企鹅兜帽" Head="197" />
+    <Item Id="3758" Name="企鹅夹克" Body="196" />
+    <Item Id="3759" Name="企鹅裤" Legs="139" />
+    <Item Id="3760" Name="呆萌粉气球墙" />
+    <Item Id="3761" Name="呆萌紫气球墙" />
+    <Item Id="3762" Name="呆萌绿气球墙" />
+    <Item Id="3763" Name="0x33飞行员" Head="198" />
+    <Item Id="3764" Name="蓝晶光刃" Scale="1.15" Rack="true" />
+    <Item Id="3765" Name="红晶光刃" Scale="1.15" Rack="true" />
+    <Item Id="3766" Name="绿晶光刃" Scale="1.15" Rack="true" />
+    <Item Id="3767" Name="紫晶光刃" Scale="1.15" Rack="true" />
+    <Item Id="3768" Name="白晶光刃" Scale="1.15" Rack="true" />
+    <Item Id="3769" Name="黄晶光刃" Scale="1.15" Rack="true" />
+    <Item Id="3770" Name="神灵诅咒" Legs="140" />
+    <Item Id="3771" Name="远古号角" />
+    <Item Id="3772" Name="颌骨剑" Rack="true" />
+    <Item Id="3773" Name="远古头饰" Head="199" />
+    <Item Id="3774" Name="远古上衣" Body="197" />
+    <Item Id="3775" Name="远古裤" Legs="141" />
+    <Item Id="3776" Name="禁戒面具" Head="200" />
+    <Item Id="3777" Name="禁戒长袍" Body="198" />
+    <Item Id="3778" Name="禁戒裤" Legs="142" />
+    <Item Id="3779" Name="神灯烈焰" Rack="true" />
+    <Item Id="3780" Name="沙尘精旗" Tally="251" />
+    <Item Id="3781" Name="袖珍镜" />
+    <Item Id="3782" Name="魔法沙粒滴管" />
+    <Item Id="3783" Name="禁戒碎片" />
+    <Item Id="3784" Name="拉弥亚蛇尾裤" Legs="143" />
+    <Item Id="3785" Name="拉弥亚披肩" Body="199" />
+    <Item Id="3786" Name="拉弥亚面具" Head="201" />
+    <Item Id="3787" Name="裂天剑" Rack="true" />
+    <Item Id="3788" Name="玛瑙爆破枪" Rack="true" />
+    <Item Id="3789" Name="沙鲨旗" Tally="252" />
+    <Item Id="3790" Name="噬骨沙鲨旗" Tally="253" />
+    <Item Id="3791" Name="戮血沙鲨旗" Tally="254" />
+    <Item Id="3792" Name="晶狐沙鲨旗" Tally="255" />
+    <Item Id="3793" Name="愤怒翻滚怪旗" Tally="256" />
+    <Item Id="3794" Name="远古布匹" />
+    <Item Id="3795" Name="沙漠幽魂灯" />
+    <Item Id="3796" Name="八音盒（沙尘暴）" />
+    <Item Id="3797" Name="学徒帽" Head="203" />
+    <Item Id="3798" Name="学徒长袍" Body="200" />
+    <Item Id="3799" Name="学徒裤" Legs="144" />
+    <Item Id="3800" Name="侍卫大头盔" Head="204" />
+    <Item Id="3801" Name="侍卫板甲" Body="201" />
+    <Item Id="3802" Name="侍卫护胫" Legs="145" />
+    <Item Id="3803" Name="女猎人假发" Head="205" />
+    <Item Id="3804" Name="女猎人上衣" Body="202" />
+    <Item Id="3805" Name="女猎人裤" Legs="146" />
+    <Item Id="3806" Name="和尚浓眉秃头帽" Head="206" />
+    <Item Id="3807" Name="和尚衣" Body="203" />
+    <Item Id="3808" Name="和尚裤" Legs="148" />
+    <Item Id="3809" Name="学徒围巾" />
+    <Item Id="3810" Name="侍卫护盾" />
+    <Item Id="3811" Name="女猎人圆盾" />
+    <Item Id="3812" Name="和尚腰带" />
+    <Item Id="3813" Name="护卫熔炉" />
+    <Item Id="3814" Name="战争桌" />
+    <Item Id="3815" Name="战争桌旗" />
+    <Item Id="3816" Name="埃特尼亚水晶座" />
+    <Item Id="3817" Name="护卫奖章" />
+    <Item Id="3818" Name="爆炸烈焰魔杖" Rack="true" />
+    <Item Id="3819" Name="爆炸烈焰手杖" Rack="true" />
+    <Item Id="3820" Name="爆炸烈焰法杖" Rack="true" />
+    <Item Id="3821" Name="麦芽酒投掷器" Rack="true" />
+    <Item Id="3822" Name="天国魔力" />
+    <Item Id="3823" Name="地狱烙印" Scale="1.15" Rack="true" />
+    <Item Id="3824" Name="弩车魔杖" Rack="true" />
+    <Item Id="3825" Name="弩车手杖" Rack="true" />
+    <Item Id="3826" Name="弩车法杖" Rack="true" />
+    <Item Id="3827" Name="飞龙" Rack="true" />
+    <Item Id="3828" Name="埃特尼亚水晶" />
+    <Item Id="3829" Name="闪电光环魔杖" Rack="true" />
+    <Item Id="3830" Name="闪电光环手杖" Rack="true" />
+    <Item Id="3831" Name="闪电光环法杖" Rack="true" />
+    <Item Id="3832" Name="爆炸机关魔杖" Rack="true" />
+    <Item Id="3833" Name="爆炸机关手杖" Rack="true" />
+    <Item Id="3834" Name="爆炸机关法杖" Rack="true" />
+    <Item Id="3835" Name="瞌睡章鱼" Rack="true" />
+    <Item Id="3836" Name="恐怖关刀" Rack="true" />
+    <Item Id="3837" Name="天国哥布林投弹手旗" Tally="257" />
+    <Item Id="3838" Name="天国哥布林旗" Tally="258" />
+    <Item Id="3839" Name="撒旦骷髅旗" Tally="259" />
+    <Item Id="3840" Name="德拉克龙旗" Tally="260" />
+    <Item Id="3841" Name="小妖魔滑翔怪旗" Tally="261" />
+    <Item Id="3842" Name="小妖魔旗" Tally="262" />
+    <Item Id="3843" Name="枯萎兽旗" Tally="263" />
+    <Item Id="3844" Name="天国飞龙旗" Tally="264" />
+    <Item Id="3845" Name="天国标枪投掷怪旗" Tally="265" />
+    <Item Id="3846" Name="天国荧光虫旗" Tally="266" />
+    <Item Id="3847" Name="食人魔面具" />
     <Item Id="3848" Name="Goblin Mask" />
     <Item Id="3849" Name="Goblin Bomber Cap" />
     <Item Id="3850" Name="Etherian Javelin" />
     <Item Id="3851" Name="Kobold Dynamite Backpack" />
-    <Item Id="3852" Name="Tome of Infinite Wisdom" Rack="true" />
+    <Item Id="3852" Name="无限智慧巨著" Rack="true" />
     <Item Id="3853" Name="Boring Bow" />
-    <Item Id="3854" Name="Phantom Phoenix" Rack="true" />
-    <Item Id="3855" Name="Gato Egg" />
-    <Item Id="3856" Name="Creeper Egg" />
-    <Item Id="3857" Name="Dragon Egg" />
-    <Item Id="3858" Name="Sky Dragon's Fury" Rack="true" />
-    <Item Id="3859" Name="Aerial Bane" Rack="true" />
-    <Item Id="3860" Name="Treasure Bag" />
-    <Item Id="3861" Name="Treasure Bag" />
-    <Item Id="3862" Name="Treasure Bag" />
-    <Item Id="3863" Name="Betsy Mask" Head="207" />
-    <Item Id="3864" Name="Dark Mage Mask" Head="208" />
-    <Item Id="3865" Name="Ogre Mask" Head="209" />
-    <Item Id="3866" Name="Betsy Trophy" />
-    <Item Id="3867" Name="Dark Mage Trophy" />
-    <Item Id="3868" Name="Ogre Trophy" />
-    <Item Id="3869" Name="Music Box (Old One's Army)" />
-    <Item Id="3870" Name="Betsy's Wrath" Rack="true" />
-    <Item Id="3871" Name="Valhalla Knight's Helm" Head="210" />
-    <Item Id="3872" Name="Valhalla Knight's Breastplate" Body="204" />
-    <Item Id="3873" Name="Valhalla Knight's Greaves" Legs="152" />
-    <Item Id="3874" Name="Dark Artist's Hat" Head="211" />
-    <Item Id="3875" Name="Dark Artist's Robes" Body="205" />
-    <Item Id="3876" Name="Dark Artist's Leggings" Legs="153" />
-    <Item Id="3877" Name="Red Riding Hood" Head="212" />
-    <Item Id="3878" Name="Red Riding Dress" Body="206" />
-    <Item Id="3879" Name="Red Riding Leggings" Legs="154" />
-    <Item Id="3880" Name="Shinobi Infiltrator's Helmet" Head="213" />
-    <Item Id="3881" Name="Shinobi Infiltrator's Torso" Body="207" />
-    <Item Id="3882" Name="Shinobi Infiltrator's Pants" Legs="156" />
-    <Item Id="3883" Name="Betsy's Wings" />
-    <Item Id="3884" Name="Crystal Chest" />
-    <Item Id="3885" Name="Golden Chest" />
-    <Item Id="3886" Name="Trapped Crystal Chest" />
-    <Item Id="3887" Name="Trapped Golden Chest" />
-    <Item Id="3888" Name="Crystal Door" />
-    <Item Id="3889" Name="Crystal Chair" />
-    <Item Id="3890" Name="Crystal Candle" />
-    <Item Id="3891" Name="Crystal Lantern" />
-    <Item Id="3892" Name="Crystal Lamp" />
-    <Item Id="3893" Name="Crystal Candelabra" />
-    <Item Id="3894" Name="Crystal Chandelier" />
-    <Item Id="3895" Name="Crystal Bathtub" />
-    <Item Id="3896" Name="Crystal Sink" />
-    <Item Id="3897" Name="Crystal Bed" />
-    <Item Id="3898" Name="Crystal Clock" />
-    <Item Id="3899" Name="Sunplate Clock" />
-    <Item Id="3900" Name="Blue Dungeon Clock" />
-    <Item Id="3901" Name="Green Dungeon Clock" />
-    <Item Id="3902" Name="Pink Dungeon Clock" />
-    <Item Id="3903" Name="Crystal Platform" />
-    <Item Id="3904" Name="Golden Platform" />
-    <Item Id="3905" Name="Dynasty Platform" />
-    <Item Id="3906" Name="Lihzahrd Platform" />
-    <Item Id="3907" Name="Flesh Platform" />
-    <Item Id="3908" Name="Frozen Platform" />
-    <Item Id="3909" Name="Crystal Work Bench" />
-    <Item Id="3910" Name="Golden Work Bench" />
-    <Item Id="3911" Name="Crystal Dresser" />
-    <Item Id="3912" Name="Dynasty Dresser" />
-    <Item Id="3913" Name="Frozen Dresser" />
-    <Item Id="3914" Name="Living Wood Dresser" />
-    <Item Id="3915" Name="Crystal Piano" />
-    <Item Id="3916" Name="Dynasty Piano" />
-    <Item Id="3917" Name="Crystal Bookcase" />
-    <Item Id="3918" Name="Crystal Sofa" />
-    <Item Id="3919" Name="Dynasty Sofa" />
-    <Item Id="3920" Name="Crystal Table" />
-    <Item Id="3921" Name="Arkhalis's Hood" Head="214" />
-    <Item Id="3922" Name="Arkhalis's Bodice" Body="208" />
-    <Item Id="3923" Name="Arkhalis's Tights" Legs="158" />
-    <Item Id="3924" Name="Arkhalis's Lightwings" />
-    <Item Id="3925" Name="Leinfors' Hair Protector" Head="215" />
-    <Item Id="3926" Name="Leinfors' Excessive Style" Body="209" />
-    <Item Id="3927" Name="Leinfors' Fancypants" Legs="159" />
-    <Item Id="3928" Name="Leinfors' Prehensile Cloak" />
-    <Item Id="3929" Name="Leinfors' Luxury Shampoo" />
+    <Item Id="3854" Name="幽灵凤凰" Rack="true" />
+    <Item Id="3855" Name="Gato蛋" />
+    <Item Id="3856" Name="飞眼怪蛋" />
+    <Item Id="3857" Name="龙蛋" />
+    <Item Id="3858" Name="天龙之怒" Rack="true" />
+    <Item Id="3859" Name="空中祸害" Rack="true" />
+    <Item Id="3860" Name="宝藏袋" />
+    <Item Id="3861" Name="宝藏袋" />
+    <Item Id="3862" Name="宝藏袋" />
+    <Item Id="3863" Name="双足翼龙面具" Head="207" />
+    <Item Id="3864" Name="暗黑魔法师面具" Head="208" />
+    <Item Id="3865" Name="食人魔面具" Head="209" />
+    <Item Id="3866" Name="双足翼龙纪念章" />
+    <Item Id="3867" Name="暗黑魔法师纪念章" />
+    <Item Id="3868" Name="食人魔纪念章" />
+    <Item Id="3869" Name="音乐盒（撒旦军队）" />
+    <Item Id="3870" Name="双足翼龙怒气" Rack="true" />
+    <Item Id="3871" Name="英灵殿骑士头盔" Head="210" />
+    <Item Id="3872" Name="英灵殿骑士胸甲" Body="204" />
+    <Item Id="3873" Name="英灵殿骑士护胫" Legs="152" />
+    <Item Id="3874" Name="暗黑艺术家帽子" Head="211" />
+    <Item Id="3875" Name="暗黑艺术家长袍" Body="205" />
+    <Item Id="3876" Name="暗黑艺术家护腿" Legs="153" />
+    <Item Id="3877" Name="红色骑术兜帽" Head="212" />
+    <Item Id="3878" Name="红色骑术服" Body="206" />
+    <Item Id="3879" Name="红色骑术护腿" Legs="154" />
+    <Item Id="3880" Name="渗透忍者头盔" Head="213" />
+    <Item Id="3881" Name="渗透忍者上衣" Body="207" />
+    <Item Id="3882" Name="渗透忍者裤装" Legs="156" />
+    <Item Id="3883" Name="双足翼龙之翼" />
+    <Item Id="3884" Name="水晶宝箱" />
+    <Item Id="3885" Name="金色宝箱" />
+    <Item Id="3886" Name="受困水晶宝箱" />
+    <Item Id="3887" Name="受困金色宝箱" />
+    <Item Id="3888" Name="水晶门" />
+    <Item Id="3889" Name="水晶椅子" />
+    <Item Id="3890" Name="水晶蜡烛" />
+    <Item Id="3891" Name="水晶灯笼" />
+    <Item Id="3892" Name="水晶灯" />
+    <Item Id="3893" Name="水晶烛台" />
+    <Item Id="3894" Name="水晶吊灯" />
+    <Item Id="3895" Name="水晶浴缸" />
+    <Item Id="3896" Name="水晶水槽" />
+    <Item Id="3897" Name="水晶床" />
+    <Item Id="3898" Name="水晶时钟" />
+    <Item Id="3899" Name="日盘时钟" />
+    <Item Id="3900" Name="蓝地牢时钟" />
+    <Item Id="3901" Name="绿地牢时钟" />
+    <Item Id="3902" Name="粉地牢时钟" />
+    <Item Id="3903" Name="水晶平台" />
+    <Item Id="3904" Name="金色平台" />
+    <Item Id="3905" Name="王朝平台" />
+    <Item Id="3906" Name="丛林蜥蜴平台" />
+    <Item Id="3907" Name="血肉平台" />
+    <Item Id="3908" Name="冰冻平台" />
+    <Item Id="3909" Name="水晶工作台" />
+    <Item Id="3910" Name="金色工作台" />
+    <Item Id="3911" Name="水晶梳妆台" />
+    <Item Id="3912" Name="王朝梳妆台" />
+    <Item Id="3913" Name="冰冻梳妆台" />
+    <Item Id="3914" Name="生命木梳妆台" />
+    <Item Id="3915" Name="水晶钢琴" />
+    <Item Id="3916" Name="王朝钢琴" />
+    <Item Id="3917" Name="水晶书架" />
+    <Item Id="3918" Name="水晶沙发" />
+    <Item Id="3919" Name="王朝沙发" />
+    <Item Id="3920" Name="水晶桌" />
+    <Item Id="3921" Name="Arkhalis的兜帽" Head="214" />
+    <Item Id="3922" Name="Arkhalis的紧身衣" Body="208" />
+    <Item Id="3923" Name="Arkhalis的紧身服" Legs="158" />
+    <Item Id="3924" Name="Arkhalis的飞翼" />
+    <Item Id="3925" Name="Leinfors的护发器" Head="215" />
+    <Item Id="3926" Name="Leinfors的奇异风" Body="209" />
+    <Item Id="3927" Name="Leinfors的潮裤" Legs="159" />
+    <Item Id="3928" Name="Leinfors的卷缠斗篷" />
+    <Item Id="3929" Name="Leinfors的奢华洗发液" />
   </Items>
   <Npcs>
     <Npc Id="17"    Name="Merchant"         Frames="25"   />


### PR DESCRIPTION
将物品名翻译为中文。
采用 1.3.5.3 的官方译名：https://terraria-zh.gamepedia.com/Terraria_Wiki:%E5%8E%9F%E5%A7%8B%E6%B8%B8%E6%88%8F%E8%B5%84%E6%BA%90%E6%96%87%E6%9C%AC%E5%AF%B9%E7%85%A7

因为是程序自动转换的，所以修正了 TEdit 原来的英文的一部分错误（与官方不同的地方）。
有些词汇没有找到对应的。
'Mudstone Brick', 'Sand Poacher Banner', 'Granite Golem Banner'
官方词汇中的这三个词 没有找到 TEdit 的对应项，TEdit 的几项也没有对应到官方。